### PR TITLE
Issue #145: Use context to communicate from BrowserFrag to Activity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Pinch to exit full screen web content like videos (#75)
 
+### Fixed
+- Toolbar not updating correctly after application state is restored (#145)
+
 ## [1.2] - ?
 ### Changed
 - Sentry crash reports include a UUID to distinguish users so we can determine if it's 1 user crashing 100 times or 100 users crashing 1 time each. This identifier is only used for Sentry and can not be correlated with telemetry interaction data. See [fire TV Sentry docs](https://github.com/mozilla-mobile/firefox-tv/wiki/Crash-reporting-with-Sentry) for more details. (#565)


### PR DESCRIPTION
The previous implementation used the fragment lifecycle callbacks but
these aren't called for fragment state restoration (go figure 🙄).

Testing with "Don't Keep Activities", state restoration appears to be
working correctly now.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - #145 is not yet complete but has an action item to write tests for the state restoration case
- [x] This PR includes a **CHANGELOG entry** or does not need one