### PR TITLE
Issue #117: Update navigation overlay to match mocks, move to new fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Pinch to exit full screen web content like videos (#75)
 
+### Changed
+- Appearance and animations of navigation overlay to more clearly overlay browser content
+
 ### Fixed
 - Toolbar not updating correctly after application state is restored (#145)
 

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -9,17 +9,16 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.AttributeSet
-import android.view.KeyEvent
 import android.view.View
 import kotlinx.android.synthetic.main.activity_main.*
-import kotlinx.android.synthetic.main.fragment_browser.*
 import mozilla.components.support.utils.SafeIntent
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
 import org.mozilla.focus.animation.VisibilityAnimator
 import org.mozilla.focus.architecture.NonNullObserver
 import org.mozilla.focus.browser.BrowserFragmentCallbacks
 import org.mozilla.focus.ext.getBrowserFragment
-import org.mozilla.focus.ext.isVisible
+import org.mozilla.focus.ext.getNavigationOverlay
+import org.mozilla.focus.ext.isVisibleAndNonNull
 import org.mozilla.focus.ext.toSafeIntent
 import org.mozilla.focus.iwebview.IWebView
 import org.mozilla.focus.iwebview.WebViewProvider
@@ -88,8 +87,8 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
     }
 
     private fun initViews() {
-        appBarLayoutController = BrowserAppBarLayoutController(appBarLayout, toolbar, appBarOverlay).apply {
-            init(supportFragmentManager::getBrowserFragment)
+        appBarLayoutController = BrowserAppBarLayoutController(appBarLayout, toolbar).apply {
+            init()
         }
     }
 
@@ -143,8 +142,7 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
     }
 
     private fun onToolbarEvent(event: ToolbarEvent, value: String?, autocompleteResult: InlineAutocompleteEditText.AutocompleteResult?) {
-        val browserFragment = supportFragmentManager.getBrowserFragment()
-        if (event == ToolbarEvent.HOME && browserFragment?.homeScreen?.isVisible == true) {
+        if (event == ToolbarEvent.HOME && supportFragmentManager.getNavigationOverlay().isVisibleAndNonNull) {
             // The home button does nothing on when home is visible.
             return
         } else if (event == ToolbarEvent.LOAD_URL) {
@@ -154,6 +152,7 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
 
         TelemetryWrapper.toolbarEvent(event, value)
 
+        val browserFragment = supportFragmentManager.getBrowserFragment()
         when (event) {
             ToolbarEvent.SETTINGS -> startActivity(Intent(this, SettingsActivity::class.java))
 //            ToolbarEvent.TURBO -> Settings.getInstance(this).isBlockingEnabled = value == ToolbarEvent.VAL_CHECKED
@@ -164,7 +163,7 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
     }
 
     override fun onHomeVisibilityChange(isHomeVisible: Boolean, isHomescreenOnStartup: Boolean) {
-        appBarLayoutController.onHomeVisibilityChange(isHomeVisible, isHomescreenOnStartup)
+        appBarLayoutController.onHomeVisibilityChange(isHomeVisible)
     }
 
     override fun onFullScreenChange(isFullscreen: Boolean) {

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -8,8 +8,6 @@ package org.mozilla.focus
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.support.v4.app.Fragment
-import android.support.v4.app.FragmentManager
 import android.util.AttributeSet
 import android.view.View
 import kotlinx.android.synthetic.main.activity_main.*
@@ -22,7 +20,6 @@ import org.mozilla.focus.ext.getBrowserFragment
 import org.mozilla.focus.ext.getNavigationOverlay
 import org.mozilla.focus.ext.isVisibleAndNonNull
 import org.mozilla.focus.ext.toSafeIntent
-import org.mozilla.focus.home.NavigationOverlayFragment
 import org.mozilla.focus.iwebview.IWebView
 import org.mozilla.focus.iwebview.WebViewProvider
 import org.mozilla.focus.locale.LocaleAwareAppCompatActivity
@@ -87,7 +84,6 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
         WebViewProvider.preload(this)
         toolbarCallbacks = ToolbarIntegration.setup(toolbar, toolbarStateProvider, ::onToolbarEvent)
         UserClearDataEvent.liveData.observe(this, UserClearDataEventObserver(this))
-        supportFragmentManager.registerFragmentLifecycleCallbacks(MainActivityFragmentLifecycleCallbacks(), true)
     }
 
     private fun initViews() {
@@ -187,32 +183,6 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
         override fun getCurrentUrl() = getBrowserToolbarProvider()?.getCurrentUrl()
         override fun isURLPinned() = getBrowserToolbarProvider()?.isURLPinned() ?: false
         override fun isStartupHomepageVisible() = getBrowserToolbarProvider()?.isStartupHomepageVisible() ?: false
-    }
-
-    private inner class MainActivityFragmentLifecycleCallbacks : FragmentManager.FragmentLifecycleCallbacks() {
-        override fun onFragmentViewCreated(
-            fragmentManager: FragmentManager?,
-            fragment: Fragment?,
-            view: View?,
-            savedInstanceState: Bundle?
-        ) {
-            if (fragment is NavigationOverlayFragment) {
-                setNavigationOverlayContainerIsVisible(true)
-            }
-        }
-
-        override fun onFragmentViewDestroyed(fragmentManager: FragmentManager?, fragment: Fragment?) {
-            if (fragment is NavigationOverlayFragment) {
-                setNavigationOverlayContainerIsVisible(false)
-            }
-        }
-
-        private fun setNavigationOverlayContainerIsVisible(isVisible: Boolean) {
-            // We set the visibility with fragment lifecycle callbacks to ensure the container visibility reflects the
-            // fragment view hierarchy state. This seamlessly handles cases where the fragments are modified but we
-            // didn't initiate it (e.g. during state restoration, active fragments will be restored but not the view hierarchy).
-            navigationOverlayContainer.visibility = if (isVisible) View.VISIBLE else View.GONE
-        }
     }
 
     override fun onHomeTileLongClick(unpinTile: () -> Unit) {

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -142,15 +142,6 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
         }
     }
 
-    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        val browserFragment = supportFragmentManager.getBrowserFragment()
-        return if (browserFragment != null && browserFragment.isVisible) {
-            browserFragment.dispatchKeyEvent(event) || super.dispatchKeyEvent(event)
-        } else {
-            super.dispatchKeyEvent(event)
-        }
-    }
-
     private fun onToolbarEvent(event: ToolbarEvent, value: String?, autocompleteResult: InlineAutocompleteEditText.AutocompleteResult?) {
         val browserFragment = supportFragmentManager.getBrowserFragment()
         if (event == ToolbarEvent.HOME && browserFragment?.homeScreen?.isVisible == true) {

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -8,6 +8,8 @@ package org.mozilla.focus
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentManager
 import android.util.AttributeSet
 import android.view.View
 import kotlinx.android.synthetic.main.activity_main.*
@@ -20,6 +22,7 @@ import org.mozilla.focus.ext.getBrowserFragment
 import org.mozilla.focus.ext.getNavigationOverlay
 import org.mozilla.focus.ext.isVisibleAndNonNull
 import org.mozilla.focus.ext.toSafeIntent
+import org.mozilla.focus.home.NavigationOverlayFragment
 import org.mozilla.focus.iwebview.IWebView
 import org.mozilla.focus.iwebview.WebViewProvider
 import org.mozilla.focus.locale.LocaleAwareAppCompatActivity
@@ -84,6 +87,7 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
         WebViewProvider.preload(this)
         toolbarCallbacks = ToolbarIntegration.setup(toolbar, toolbarStateProvider, ::onToolbarEvent)
         UserClearDataEvent.liveData.observe(this, UserClearDataEventObserver(this))
+        supportFragmentManager.registerFragmentLifecycleCallbacks(MainActivityFragmentLifecycleCallbacks(), true)
     }
 
     private fun initViews() {
@@ -183,6 +187,32 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
         override fun getCurrentUrl() = getBrowserToolbarProvider()?.getCurrentUrl()
         override fun isURLPinned() = getBrowserToolbarProvider()?.isURLPinned() ?: false
         override fun isStartupHomepageVisible() = getBrowserToolbarProvider()?.isStartupHomepageVisible() ?: false
+    }
+
+    private inner class MainActivityFragmentLifecycleCallbacks : FragmentManager.FragmentLifecycleCallbacks() {
+        override fun onFragmentViewCreated(
+            fragmentManager: FragmentManager?,
+            fragment: Fragment?,
+            view: View?,
+            savedInstanceState: Bundle?
+        ) {
+            if (fragment is NavigationOverlayFragment) {
+                setNavigationOverlayContainerIsVisible(true)
+            }
+        }
+
+        override fun onFragmentViewDestroyed(fragmentManager: FragmentManager?, fragment: Fragment?) {
+            if (fragment is NavigationOverlayFragment) {
+                setNavigationOverlayContainerIsVisible(false)
+            }
+        }
+
+        private fun setNavigationOverlayContainerIsVisible(isVisible: Boolean) {
+            // We set the visibility with fragment lifecycle callbacks to ensure the container visibility reflects the
+            // fragment view hierarchy state. This seamlessly handles cases where the fragments are modified but we
+            // didn't initiate it (e.g. during state restoration, active fragments will be restored but not the view hierarchy).
+            navigationOverlayContainer.visibility = if (isVisible) View.VISIBLE else View.GONE
+        }
     }
 
     override fun onHomeTileLongClick(unpinTile: () -> Unit) {

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -210,7 +210,7 @@ class BrowserFragment : IWebViewLifecycleFragment() {
 
         if (isVisible) {
             NavigationOverlayFragment.newInstance(isInitialHomescreen = isHomescreenOnStartup)
-                .show(fragmentManager!!, activity!!)
+                .show(fragmentManager!!)
         } else if (!isHomescreenOnStartup) {
             fragmentManager.getNavigationOverlay()?.dismiss()
         }

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -8,23 +8,20 @@ import android.arch.lifecycle.Observer
 import android.content.Context
 import android.os.Bundle
 import android.text.TextUtils
-import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.accessibility.AccessibilityManager.TouchExplorationStateChangeListener
-import kotlinx.android.synthetic.main.fragment_browser.*
-import kotlinx.android.synthetic.main.fragment_browser.view.*
-import kotlinx.coroutines.experimental.CancellationException
 import org.mozilla.focus.R
-import org.mozilla.focus.UrlSearcher
 import org.mozilla.focus.browser.URLs.APP_STARTUP_HOME
 import org.mozilla.focus.ext.getAccessibilityManager
-import org.mozilla.focus.ext.isVisible
+import org.mozilla.focus.ext.getNavigationOverlay
+import org.mozilla.focus.ext.isVisibleAndNonNull
 import org.mozilla.focus.ext.isVoiceViewEnabled
 import org.mozilla.focus.ext.toUri
 import org.mozilla.focus.home.BundledTilesManager
 import org.mozilla.focus.home.CustomTilesManager
+import org.mozilla.focus.home.NavigationOverlayFragment
 import org.mozilla.focus.iwebview.IWebView
 import org.mozilla.focus.iwebview.IWebViewLifecycleFragment
 import org.mozilla.focus.session.NullSession
@@ -95,7 +92,7 @@ class BrowserFragment : IWebViewLifecycleFragment() {
             // We prevent users from typing this URL in loadUrl but this will still be called for
             // the initial URL set in the Session.
             if (url == APP_STARTUP_HOME.toString()) {
-                homeScreen.visibility = View.VISIBLE
+                setNavigationOverlayIsVisible(true, isHomescreenOnStartup = true)
             }
 
             callbacks?.onUrlUpdate(url) // This should be called last so app state is up-to-date.
@@ -104,7 +101,8 @@ class BrowserFragment : IWebViewLifecycleFragment() {
     // If the URL is startup home, the home screen should always be visible. For defensiveness, we
     // also check this condition. It's probably not necessary (it was originally added when the startup
     // url was the empty string which I was concerned the WebView could pass to us while loading).
-    private val isStartupHomepageVisible: Boolean get() = url == APP_STARTUP_HOME.toString() && homeScreen.isVisible
+    private val isStartupHomepageVisible: Boolean
+        get() = url == APP_STARTUP_HOME.toString() && fragmentManager.getNavigationOverlay().isVisibleAndNonNull
 
     private val sessionManager = SessionManager.getInstance()
 
@@ -155,7 +153,8 @@ class BrowserFragment : IWebViewLifecycleFragment() {
             ToolbarEvent.RELOAD -> webView?.reload()
             ToolbarEvent.SETTINGS -> Unit // No Settings in BrowserFragment
             ToolbarEvent.PIN_ACTION -> this@BrowserFragment.url?.let { url -> onPinToolbarEvent(context, url, value) }
-            ToolbarEvent.HOME -> if (!homeScreen.isVisible) { homeScreen.setVisibilityWithAnimation(toShow = true)
+            ToolbarEvent.HOME -> if (!fragmentManager.getNavigationOverlay().isVisibleAndNonNull) {
+                setNavigationOverlayIsVisible(true)
             }
 
             ToolbarEvent.LOAD_URL -> throw IllegalStateException("Expected $event to be handled sooner")
@@ -168,7 +167,7 @@ class BrowserFragment : IWebViewLifecycleFragment() {
             ToolbarEvent.VAL_CHECKED -> {
                 CustomTilesManager.getInstance(context).pinSite(context, url,
                         webView?.takeScreenshot())
-                homeScreen.refreshTilesForInsertion()
+                fragmentManager.getNavigationOverlay()?.refreshTilesForInsertion()
                 ToastManager.showPinnedToast(context)
             }
             ToolbarEvent.VAL_UNCHECKED -> {
@@ -178,7 +177,7 @@ class BrowserFragment : IWebViewLifecycleFragment() {
                     // tileId should never be null, unless, for some reason we don't
                     // have a reference to the tile/the tile isn't a Bundled or Custom tile
                     if (tileId != null && !tileId.isEmpty()) {
-                        homeScreen.removePinnedSiteFromTiles(tileId)
+                        fragmentManager.getNavigationOverlay()?.removePinnedSiteFromTiles(tileId)
                         ToastManager.showUnpinnedToast(context)
                     }
                 }
@@ -190,24 +189,8 @@ class BrowserFragment : IWebViewLifecycleFragment() {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         val layout = inflater.inflate(R.layout.fragment_browser, container, false)
 
-        with(layout.homeScreen) {
-            onTileClicked = { callbacks?.onNonTextInputUrlEntered(it) }
-            urlSearcher = activity as UrlSearcher
-            visibility = View.GONE
-            onPreSetVisibilityListener = { isHomeVisible ->
-                // It's a pre-set-visibility listener so we can't use toolbarStateProvider.isStartupHomePageVisible.
-                callbacks?.onHomeVisibilityChange(isHomeVisible, url == APP_STARTUP_HOME.toString())
-                updateWebViewVisibility(isVoiceViewEnabled = context.isVoiceViewEnabled(), isHomeVisible = isHomeVisible)
-            }
-            homeTileLongClickListener = object : HomeTileLongClickListener {
-                override fun onHomeTileLongClick(unpinTile: () -> Unit) {
-                    callbacks?.onHomeTileLongClick(unpinTile)
-                }
-            }
-        }
-
         touchExplorationStateChangeListener = BrowserTouchExplorationStateChangeListener(
-                layout.homeScreen, this::updateWebViewVisibility).also {
+                fragmentManager::getNavigationOverlay, this::updateWebViewVisibility).also {
             layout.context.getAccessibilityManager().addTouchExplorationStateChangeListener(it)
         }
 
@@ -219,23 +202,33 @@ class BrowserFragment : IWebViewLifecycleFragment() {
 
         context?.getAccessibilityManager()?.removeTouchExplorationStateChangeListener(touchExplorationStateChangeListener)
         touchExplorationStateChangeListener = null
+    }
 
-        // Since we start the async jobs in View.init and Android is inflating the view for us,
-        // there's no good way to pass in the uiLifecycleJob. We could consider other solutions
-        // but it'll add complexity that I don't think is probably worth it.
-        homeScreen.uiLifecycleCancelJob.cancel(CancellationException("Parent lifecycle has ended"))
+    private fun setNavigationOverlayIsVisible(isVisible: Boolean, isHomescreenOnStartup: Boolean = false) {
+        callbacks?.onHomeVisibilityChange(isVisible, isHomescreenOnStartup = isHomescreenOnStartup)
+        updateWebViewVisibility(isVoiceViewEnabled = context!!.isVoiceViewEnabled(), isHomescreenOnStartup = isHomescreenOnStartup)
+
+        if (isVisible) {
+            NavigationOverlayFragment.newInstance(isInitialHomescreen = isHomescreenOnStartup)
+                .show(fragmentManager!!, activity!!)
+        } else if (!isHomescreenOnStartup) {
+            fragmentManager.getNavigationOverlay()?.dismiss()
+        }
     }
 
     fun loadUrl(url: String) {
-        // Intents can trigger loadUrl, and we need to make sure the homescreen is always hidden.
-        homeScreen.setVisibilityWithAnimation(toShow = false)
+        // Intents can trigger loadUrl, and we need to make sure the navigation overlay is always hidden.
+        setNavigationOverlayIsVisible(false)
         val webView = webView
         if (webView != null && !TextUtils.isEmpty(url) && !URLS_BLOCKED_FROM_USERS.contains(url)) {
             webView.loadUrl(url)
         }
     }
 
-    private fun updateWebViewVisibility(isVoiceViewEnabled: Boolean, isHomeVisible: Boolean) {
+    private fun updateWebViewVisibility(
+        isVoiceViewEnabled: Boolean,
+        isHomescreenOnStartup: Boolean
+    ) {
         // We want to disable accessibility on the WebView when the home screen is visible so users
         // cannot focus the WebView content below home tiles. Unfortunately, isFocusable* and
         // setImportantForAccessibility didn't work so the only way I could disable WebView
@@ -244,8 +237,8 @@ class BrowserFragment : IWebViewLifecycleFragment() {
         // display the home tiles over the partially visible, unfocusable WebView, invalidating the
         // hide-it-for-everyone approach so it seemed simpler to only hide the WebView for a11y users
         // in this simple place.
-        val isWebViewVisible = !isVoiceViewEnabled || !isHomeVisible
-        webView?.setVisibility(if (isWebViewVisible) View.VISIBLE else View.GONE)
+        val isWebViewHidden = isVoiceViewEnabled && isHomescreenOnStartup
+        webView?.setVisibility(if (isWebViewHidden) View.GONE else View.VISIBLE)
     }
 
     inner class BrowserToolbarStateProvider : ToolbarStateProvider {
@@ -272,10 +265,10 @@ class BrowserFragment : IWebViewLifecycleFragment() {
 }
 
 private class BrowserTouchExplorationStateChangeListener(
-    private val homeScreen: HomeTileGridNavigation,
+    private val navigationOverlayProvider: () -> NavigationOverlayFragment?,
     private val updateWebViewVisibility: (isVoiceViewEnabled: Boolean, isHomeVisible: Boolean) -> Unit
 ) : TouchExplorationStateChangeListener {
     override fun onTouchExplorationStateChanged(isVoiceViewEnabled: Boolean) { // touch exploration state = VoiceView
-        updateWebViewVisibility(isVoiceViewEnabled, homeScreen.isVisible)
+        updateWebViewVisibility(isVoiceViewEnabled, navigationOverlayProvider().isVisibleAndNonNull)
     }
 }

--- a/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/BrowserFragment.kt
@@ -235,16 +235,6 @@ class BrowserFragment : IWebViewLifecycleFragment() {
         }
     }
 
-    fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        /**
-         * Key handling order:
-         * - Menu to control overlay
-         * - Youtube remap of BACK to ESC
-         * - Return false, as unhandled
-         */
-        return handleSpecialKeyEvent(event)
-    }
-
     private fun updateWebViewVisibility(isVoiceViewEnabled: Boolean, isHomeVisible: Boolean) {
         // We want to disable accessibility on the WebView when the home screen is visible so users
         // cannot focus the WebView content below home tiles. Unfortunately, isFocusable* and
@@ -256,16 +246,6 @@ class BrowserFragment : IWebViewLifecycleFragment() {
         // in this simple place.
         val isWebViewVisible = !isVoiceViewEnabled || !isHomeVisible
         webView?.setVisibility(if (isWebViewVisible) View.VISIBLE else View.GONE)
-    }
-
-    private fun handleSpecialKeyEvent(event: KeyEvent): Boolean {
-        if (!homeScreen.isVisible && webView!!.isYoutubeTV &&
-                event.keyCode == KeyEvent.KEYCODE_BACK) {
-            val escKeyEvent = KeyEvent(event.action, KeyEvent.KEYCODE_ESCAPE)
-            activity?.dispatchKeyEvent(escKeyEvent)
-            return true
-        }
-        return false
     }
 
     inner class BrowserToolbarStateProvider : ToolbarStateProvider {

--- a/app/src/main/java/org/mozilla/focus/browser/HomeTileGridNavigation.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/HomeTileGridNavigation.kt
@@ -26,8 +26,7 @@ class HomeTileGridNavigation @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyle: Int = 0
-)
-    : RecyclerView(context, attrs, defStyle) {
+) : RecyclerView(context, attrs, defStyle) {
 
     /**
      * Used to cancel background->UI threads: we attach them as children to this job

--- a/app/src/main/java/org/mozilla/focus/browser/HomeTileGridNavigation.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/HomeTileGridNavigation.kt
@@ -4,11 +4,8 @@
 
 package org.mozilla.focus.browser
 
-import android.animation.Animator
-import android.animation.AnimatorListenerAdapter
 import android.content.Context
 import android.preference.PreferenceManager
-import android.support.v4.view.animation.FastOutSlowInInterpolator
 import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
 import android.view.View
@@ -83,29 +80,6 @@ class HomeTileGridNavigation @JvmOverloads constructor(
         onPreSetVisibilityListener?.invoke(visibility == View.VISIBLE)
         super.setVisibility(visibility)
         scrollTo(0, 0)
-    }
-
-    fun setVisibilityWithAnimation(toShow: Boolean) {
-        val newVisibility = if (toShow) View.VISIBLE else View.GONE
-        if (visibility == newVisibility) { return }
-
-        if (toShow) { visibility = View.VISIBLE }
-
-        val screenHeight = resources.displayMetrics.heightPixels.toFloat()
-        translationY = if (toShow) screenHeight else 0f
-        animate()
-                .setInterpolator(FastOutSlowInInterpolator())
-                .setDuration(400)
-                .translationY(if (toShow) 0f else screenHeight)
-                .setListener(object : AnimatorListenerAdapter() {
-                    override fun onAnimationEnd(animation: Animator?) {
-                        if (!toShow) {
-                            visibility = View.GONE
-                            translationY = 0f // Reset the position for next show.
-                        }
-                    }
-                })
-                .start()
     }
 
     fun refreshTilesForInsertion() {

--- a/app/src/main/java/org/mozilla/focus/browser/HomeTileGridNavigation.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/HomeTileGridNavigation.kt
@@ -40,7 +40,7 @@ class HomeTileGridNavigation @JvmOverloads constructor(
     // thus we need to use Delegates.observable to update onTileLongClick.
     var homeTileLongClickListener: HomeTileLongClickListener? = null
 
-    lateinit var onTileClicked: (value: String) -> Unit
+    var onTileClicked: ((value: String) -> Unit)? = null
     var urlSearcher: UrlSearcher? = null
     /** Called inside [setVisibility] right before super.setVisibility is called. */
     var onPreSetVisibilityListener: ((isVisible: Boolean) -> Unit)? = null
@@ -57,7 +57,7 @@ class HomeTileGridNavigation @JvmOverloads constructor(
 
         adapter = HomeTileAdapter(uiLifecycleCancelJob, homeTiles, loadUrl = { urlStr ->
             if (urlStr.isNotEmpty()) {
-                onTileClicked.invoke(urlStr)
+                onTileClicked?.invoke(urlStr)
             }
         }, onTileFocused = {
             val prefInt = PreferenceManager.getDefaultSharedPreferences(context).getInt(SHOW_UNPIN_TOAST_COUNTER_PREF, 0)

--- a/app/src/main/java/org/mozilla/focus/ext/Fragment.kt
+++ b/app/src/main/java/org/mozilla/focus/ext/Fragment.kt
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.ext
+
+import android.support.v4.app.Fragment
+
+val Fragment?.isVisibleAndNonNull: Boolean
+    get() = this != null && this.isVisible

--- a/app/src/main/java/org/mozilla/focus/ext/FragmentManager.kt
+++ b/app/src/main/java/org/mozilla/focus/ext/FragmentManager.kt
@@ -6,6 +6,10 @@ package org.mozilla.focus.ext
 
 import android.support.v4.app.FragmentManager
 import org.mozilla.focus.browser.BrowserFragment
+import org.mozilla.focus.home.NavigationOverlayFragment
 
-fun FragmentManager.getBrowserFragment(): BrowserFragment? =
-        findFragmentByTag(BrowserFragment.FRAGMENT_TAG) as BrowserFragment?
+fun FragmentManager?.getBrowserFragment(): BrowserFragment? =
+        this?.findFragmentByTag(BrowserFragment.FRAGMENT_TAG) as BrowserFragment?
+
+fun FragmentManager?.getNavigationOverlay(): NavigationOverlayFragment? =
+        this?.findFragmentByTag(NavigationOverlayFragment.FRAGMENT_TAG) as NavigationOverlayFragment?

--- a/app/src/main/java/org/mozilla/focus/ext/View.kt
+++ b/app/src/main/java/org/mozilla/focus/ext/View.kt
@@ -6,6 +6,7 @@ package org.mozilla.focus.ext
 
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 
 val View.isVisible: Boolean get() = (visibility == View.VISIBLE)
 
@@ -14,4 +15,20 @@ inline fun View.updateLayoutParams(mutateLayoutParams: (ViewGroup.LayoutParams) 
     val layoutParams = this.layoutParams
     mutateLayoutParams(layoutParams)
     this.layoutParams = layoutParams // Calling setLayoutParams forces them to refresh internally.
+}
+
+/**
+ * Calls the given function on the next global layout call and never again.
+ *
+ * This may be replacable by ktx's View.doOnLayout.
+ */
+fun View.onGlobalLayoutOnce(onGlobalLayout: () -> Unit) {
+    viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
+        override fun onGlobalLayout() {
+            // We must get the view tree observer again: a view tree observer reference can become inactive
+            // so we can't reuse it.
+            viewTreeObserver.removeOnGlobalLayoutListener(this)
+            onGlobalLayout()
+        }
+    })
 }

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayAnimations.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayAnimations.kt
@@ -18,8 +18,8 @@ import org.mozilla.focus.ext.onGlobalLayoutOnce
  */
 object NavigationOverlayAnimations {
 
-    fun onCreateViewAnimateIn(overlay: View, isInitialHomescreen: Boolean, onAnimationEnd: () -> Unit) {
-        if (isInitialHomescreen) {
+    fun onCreateViewAnimateIn(overlay: View, isInitialHomescreen: Boolean, isBeingRestored: Boolean, onAnimationEnd: () -> Unit) {
+        if (isInitialHomescreen || isBeingRestored) {
             onAnimationEnd()
             return
         }

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayAnimations.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayAnimations.kt
@@ -26,17 +26,17 @@ object NavigationOverlayAnimations {
 
         // View positions are not set in onCreateView so we must wait for layout.
         overlay.onGlobalLayoutOnce {
-            getAnimation(overlay, isAnimateIn = true, onAnimationEnd = onAnimationEnd).start()
+            getAnimator(overlay, isAnimateIn = true, onAnimationEnd = onAnimationEnd).start()
         }
     }
 
     fun animateOut(overlay: View, isInitialHomescreen: Boolean, onAnimationEnd: () -> Unit) {
-        getAnimation(overlay, isAnimateIn = false, isInitialHomescreen = isInitialHomescreen, onAnimationEnd = onAnimationEnd)
+        getAnimator(overlay, isAnimateIn = false, isInitialHomescreen = isInitialHomescreen, onAnimationEnd = onAnimationEnd)
             .start()
     }
 
     @Suppress("SpreadOperator") // It reduces repetition and the arrays are small so perf impact is negligible.
-    private fun getAnimation(
+    private fun getAnimator(
         overlay: View,
         isAnimateIn: Boolean,
         isInitialHomescreen: Boolean = false,

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayAnimations.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayAnimations.kt
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.home
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.animation.AnimatorSet
+import android.animation.ObjectAnimator
+import android.support.v4.view.animation.FastOutSlowInInterpolator
+import android.view.View
+import kotlinx.android.synthetic.main.fragment_navigation_overlay.view.*
+import org.mozilla.focus.ext.onGlobalLayoutOnce
+
+/**
+ * Encapsulation of animation code for the navigation overlay.
+ */
+object NavigationOverlayAnimations {
+
+    fun onCreateViewAnimateIn(overlay: View, isInitialHomescreen: Boolean) {
+        if (isInitialHomescreen) return
+
+        // View positions are not set in onCreateView so we must wait for layout.
+        overlay.onGlobalLayoutOnce {
+            getAnimation(overlay, isAnimateIn = true).start()
+        }
+    }
+
+    fun animateOut(overlay: View, isInitialHomescreen: Boolean, onAnimationEnd: () -> Unit) {
+        val animation = getAnimation(overlay, isAnimateIn = false, isInitialHomescreen = isInitialHomescreen)
+        animation.addListener(object : AnimatorListenerAdapter() {
+            override fun onAnimationEnd(animation: Animator?) {
+                onAnimationEnd()
+            }
+        })
+        animation.start()
+    }
+
+    @Suppress("SpreadOperator") // It reduces repetition and the arrays are small so perf impact is negligible.
+    private fun getAnimation(overlay: View, isAnimateIn: Boolean, isInitialHomescreen: Boolean = false): Animator {
+        val fadeValues = if (isAnimateIn) floatArrayOf(0f, 1f) else floatArrayOf(1f, 0f)
+        val semiOpaqueBackgroundAnimator = ObjectAnimator.ofFloat(overlay.semiOpaqueBackground, "alpha", *fadeValues)
+
+        val initialHomescreenBackgroundAnimator = if (!isInitialHomescreen) {
+            null
+        } else {
+            ObjectAnimator.ofFloat(overlay.initialHomescreenBackground, "alpha", 1f, 0f)
+        }
+
+        val screenHeight = overlay.resources.displayMetrics.heightPixels.toFloat()
+        fun getTranslateUpAnimator(view: View): Animator {
+            val viewOffsetToBottomOfScreen = screenHeight - view.y
+            val translateValues =
+                if (isAnimateIn) floatArrayOf(viewOffsetToBottomOfScreen, 0f) else floatArrayOf(0f, viewOffsetToBottomOfScreen)
+            return ObjectAnimator.ofFloat(view, "translationY", *translateValues)
+        }
+
+        return AnimatorSet().apply {
+            duration = 400
+            interpolator = FastOutSlowInInterpolator()
+
+            val animatorSetBuilder = play(semiOpaqueBackgroundAnimator)
+            arrayOf(overlay.homeTiles, overlay.backgroundView, overlay.backgroundShadowView).forEach {
+                animatorSetBuilder.with(getTranslateUpAnimator(it))
+            }
+            initialHomescreenBackgroundAnimator?.let { animatorSetBuilder.with(it) }
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
@@ -54,6 +54,8 @@ class NavigationOverlayFragment : Fragment() {
             }
         }
 
+        overlay.initialHomescreenBackground.visibility = if (isInitialHomescreen) View.VISIBLE else View.GONE
+
         with(overlay.homeTiles) {
             onTileClicked = { callbacks?.onNonTextInputUrlEntered(it) }
             urlSearcher = activity as UrlSearcher

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
@@ -6,6 +6,10 @@ package org.mozilla.focus.home
 
 import android.app.Activity
 import android.os.Bundle
+import android.support.annotation.IdRes
+import android.support.constraint.ConstraintLayout
+import android.support.constraint.ConstraintLayout.LayoutParams.MATCH_CONSTRAINT_SPREAD
+import android.support.constraint.ConstraintLayout.LayoutParams.MATCH_CONSTRAINT_WRAP
 import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentManager
 import android.view.LayoutInflater
@@ -77,12 +81,25 @@ class NavigationOverlayFragment : Fragment() {
 
     private fun setOverlayHeight(homeTiles: HomeTileGridNavigation) {
         homeTiles.updateLayoutParams {
-            // Since we're attached to a full screen view decoupled from the app bar, we need to use
-            // the app bar height to position the navigation below the app bar.
-            //
-            // The current layout implementation makes setting the height through margins convenient.
-            val params = it as ViewGroup.MarginLayoutParams
-            params.topMargin = resources.getDimensionPixelSize(R.dimen.appbar_height)
+            val verticalBias: Float
+            val heightConstraintType: Int
+            @IdRes val topToBottom: Int
+            if (isInitialHomescreen) {
+                // Fill constraints from top to bottom (app bar to bottom of screen).
+                verticalBias = 0f
+                heightConstraintType = MATCH_CONSTRAINT_SPREAD
+                topToBottom = R.id.overlayTopAsInitialHomescreen
+            } else {
+                // Set height based on content size, expanding up from the bottom.
+                verticalBias = 1f
+                heightConstraintType = MATCH_CONSTRAINT_WRAP
+                topToBottom = R.id.overlayTopAsDialog
+            }
+
+            val params = it as ConstraintLayout.LayoutParams
+            params.verticalBias = verticalBias
+            params.matchConstraintDefaultHeight = heightConstraintType
+            params.topToBottom = topToBottom
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.home
+
+import android.app.Activity
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.support.v4.app.FragmentManager
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import kotlinx.android.synthetic.main.fragment_navigation_overlay.*
+import kotlinx.android.synthetic.main.fragment_navigation_overlay.view.*
+import kotlinx.coroutines.experimental.CancellationException
+import org.mozilla.focus.R
+import org.mozilla.focus.UrlSearcher
+import org.mozilla.focus.browser.BrowserFragmentCallbacks
+import org.mozilla.focus.browser.HomeTileGridNavigation
+import org.mozilla.focus.browser.HomeTileLongClickListener
+import org.mozilla.focus.ext.updateLayoutParams
+import org.mozilla.focus.telemetry.TelemetryWrapper
+
+private const val KEY_IS_INITIAL_HOMESCREEN = "isInitialHomescreen"
+
+/**
+ * An overlay that allows the user to navigate to new pages including via the home tiles. The overlay
+ * should be added to a fullscreen view and can be used in two modes:
+ * - Initial homescreen: navigation is placed below the app bar
+ * - Dialog: navigation is full screen, overlaid on a semi opaque overlay
+ *
+ * Note: this was originally implemented as a DialogFragment to better decouple the UI of the overlay from the
+ * app but there was a long delay before it could be displayed so we switched to a regular Fragment.
+ */
+class NavigationOverlayFragment : Fragment() {
+
+    private val isInitialHomescreen: Boolean by lazy { arguments!!.getBoolean(KEY_IS_INITIAL_HOMESCREEN) }
+
+    private val callbacks: BrowserFragmentCallbacks? get() = activity as BrowserFragmentCallbacks?
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val overlay = inflater.inflate(R.layout.fragment_navigation_overlay, container, false)
+
+        with(overlay.semiOpaqueBackground) {
+            visibility = if (isInitialHomescreen) View.GONE else View.VISIBLE
+            setOnClickListener {
+                dismiss()
+                TelemetryWrapper.dismissHomeOverlayClickEvent()
+            }
+        }
+
+        with(overlay.homeTiles) {
+            onTileClicked = { callbacks?.onNonTextInputUrlEntered(it) }
+            urlSearcher = activity as UrlSearcher
+
+            homeTileLongClickListener = object : HomeTileLongClickListener {
+                override fun onHomeTileLongClick(unpinTile: () -> Unit) {
+                    callbacks?.onHomeTileLongClick(unpinTile)
+                }
+            }
+        }
+
+        setOverlayHeight(overlay.homeTiles)
+
+        return overlay
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+
+        // Since we start the async jobs in View.init and Android is inflating the view for us,
+        // there's no good way to pass in the uiLifecycleJob. We could consider other solutions
+        // but it'll add complexity that I don't think is probably worth it.
+        homeTiles.uiLifecycleCancelJob.cancel(CancellationException("Parent lifecycle has ended"))
+    }
+
+    private fun setOverlayHeight(homeTiles: HomeTileGridNavigation) {
+        homeTiles.updateLayoutParams {
+            // Since we're attached to a full screen view decoupled from the app bar, we need to use
+            // the app bar height to position the navigation below the app bar.
+            //
+            // The current layout implementation makes setting the height through margins convenient.
+            val params = it as ViewGroup.MarginLayoutParams
+            params.topMargin = resources.getDimensionPixelSize(R.dimen.appbar_height)
+        }
+    }
+
+    fun show(fragmentManager: FragmentManager, activity: Activity) {
+        activity.getNavigationOverlayContainer().visibility = View.VISIBLE
+        fragmentManager.beginTransaction()
+            .replace(R.id.navigationOverlayContainer, this, FRAGMENT_TAG)
+            .commit()
+    }
+
+    fun dismiss() {
+        activity!!.getNavigationOverlayContainer().visibility = View.GONE
+        fragmentManager!!.beginTransaction()
+            .remove(this)
+            .commit()
+    }
+
+    fun refreshTilesForInsertion() {
+        homeTiles.refreshTilesForInsertion()
+    }
+
+    fun removePinnedSiteFromTiles(tileId: String) {
+        homeTiles.removePinnedSiteFromTiles(tileId)
+    }
+
+    companion object {
+        const val FRAGMENT_TAG = "navOverlay"
+
+        fun newInstance(isInitialHomescreen: Boolean) = NavigationOverlayFragment().apply {
+            arguments = Bundle().apply {
+                putBoolean(KEY_IS_INITIAL_HOMESCREEN, isInitialHomescreen)
+            }
+        }
+    }
+}
+
+private fun Activity.getNavigationOverlayContainer(): ViewGroup = findViewById(R.id.navigationOverlayContainer)

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
@@ -94,9 +94,9 @@ class NavigationOverlayFragment : Fragment() {
     }
 
     private fun setOnClickListeners(overlay: View) {
-        // We remove the click listeners when dismissing the overlay
-        // so that clicking them doesn't restart the animation.
         fun removeClickListeners() {
+            // We remove the click listeners when dismissing the overlay
+            // so that clicking them doesn't restart the animation.
             overlay.semiOpaqueBackground.setOnClickListener(null)
             with(overlay.homeTiles) {
                 onTileClicked = {}

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
@@ -51,7 +51,8 @@ class NavigationOverlayFragment : Fragment() {
         overlay.homeTiles.urlSearcher = activity as UrlSearcher
 
         setOverlayHeight(overlay.homeTiles)
-        NavigationOverlayAnimations.onCreateViewAnimateIn(overlay, isInitialHomescreen) {
+
+        NavigationOverlayAnimations.onCreateViewAnimateIn(overlay, isInitialHomescreen, isBeingRestored = savedInstanceState != null) {
             // We defer setting click listeners until the animation completes
             // so the animation will not be interrupted.
             setOnClickListeners(overlay)

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
@@ -99,7 +99,7 @@ class NavigationOverlayFragment : Fragment() {
             // so that clicking them doesn't restart the animation.
             overlay.semiOpaqueBackground.setOnClickListener(null)
             with(overlay.homeTiles) {
-                onTileClicked = {}
+                onTileClicked = null
                 homeTileLongClickListener = null
             }
         }

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.focus.home
 
-import android.app.Activity
 import android.os.Bundle
 import android.support.annotation.IdRes
 import android.support.constraint.ConstraintLayout
@@ -125,8 +124,7 @@ class NavigationOverlayFragment : Fragment() {
         }
     }
 
-    fun show(fragmentManager: FragmentManager, activity: Activity) {
-        activity.getNavigationOverlayContainer().visibility = View.VISIBLE
+    fun show(fragmentManager: FragmentManager) {
         fragmentManager.beginTransaction()
             .replace(R.id.navigationOverlayContainer, this, FRAGMENT_TAG)
             .commit()
@@ -134,7 +132,6 @@ class NavigationOverlayFragment : Fragment() {
 
     fun dismiss() {
         NavigationOverlayAnimations.animateOut(view!!, isInitialHomescreen) {
-            activity!!.getNavigationOverlayContainer().visibility = View.GONE
             fragmentManager!!.beginTransaction()
                 .remove(this)
                 .commit()
@@ -159,5 +156,3 @@ class NavigationOverlayFragment : Fragment() {
         }
     }
 }
-
-private fun Activity.getNavigationOverlayContainer(): ViewGroup = findViewById(R.id.navigationOverlayContainer)

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
@@ -68,6 +68,7 @@ class NavigationOverlayFragment : Fragment() {
         }
 
         setOverlayHeight(overlay.homeTiles)
+        NavigationOverlayAnimations.onCreateViewAnimateIn(overlay, isInitialHomescreen)
 
         return overlay
     }
@@ -113,10 +114,12 @@ class NavigationOverlayFragment : Fragment() {
     }
 
     fun dismiss() {
-        activity!!.getNavigationOverlayContainer().visibility = View.GONE
-        fragmentManager!!.beginTransaction()
-            .remove(this)
-            .commit()
+        NavigationOverlayAnimations.animateOut(view!!, isInitialHomescreen) {
+            activity!!.getNavigationOverlayContainer().visibility = View.GONE
+            fragmentManager!!.beginTransaction()
+                .remove(this)
+                .commit()
+        }
     }
 
     fun refreshTilesForInsertion() {

--- a/app/src/main/java/org/mozilla/focus/iwebview/IWebView.kt
+++ b/app/src/main/java/org/mozilla/focus/iwebview/IWebView.kt
@@ -75,8 +75,6 @@ interface IWebView {
     @CheckResult
     fun takeScreenshot(): Bitmap
 
-    val isYoutubeTV: Boolean get() = getUrl()?.contains("youtube.com/tv") ?: false
-
     /**
      * Enable/Disable content blocking for this session (Only the blockers that are
      * enabled in the app's settings will be turned on/off).

--- a/app/src/main/java/org/mozilla/focus/toolbar/BrowserAppBarLayoutController.kt
+++ b/app/src/main/java/org/mozilla/focus/toolbar/BrowserAppBarLayoutController.kt
@@ -9,17 +9,11 @@ import android.support.design.widget.AppBarLayout.LayoutParams.SCROLL_FLAG_ENTER
 import android.support.design.widget.AppBarLayout.LayoutParams.SCROLL_FLAG_EXIT_UNTIL_COLLAPSED
 import android.support.design.widget.AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
 import android.support.design.widget.AppBarLayout.LayoutParams.SCROLL_FLAG_SNAP
-import android.view.View
 import android.view.accessibility.AccessibilityManager
-import kotlinx.android.synthetic.main.fragment_browser.*
 import mozilla.components.browser.toolbar.BrowserToolbar
-import org.mozilla.focus.browser.BrowserFragment
 import org.mozilla.focus.ext.getAccessibilityManager
 import org.mozilla.focus.ext.isVoiceViewEnabled
 import org.mozilla.focus.ext.updateLayoutParams
-import org.mozilla.focus.telemetry.TelemetryWrapper
-import android.view.View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS as A11Y_NO_HIDE_DESCENDANTS
-import android.view.View.IMPORTANT_FOR_ACCESSIBILITY_YES as A11Y_YES
 
 private const val TOOLBAR_SCROLL_ENABLED_FLAGS = SCROLL_FLAG_SCROLL or
         SCROLL_FLAG_ENTER_ALWAYS or
@@ -29,21 +23,15 @@ private const val TOOLBAR_SCROLL_ENABLED_FLAGS = SCROLL_FLAG_SCROLL or
 /** A view controller for the [AppBarLayout] and the [BrowserToolbar] it contains. */
 class BrowserAppBarLayoutController(
     private val appBarLayout: AppBarLayout,
-    private val toolbar: BrowserToolbar,
-    private val appBarOverlay: View
+    private val toolbar: BrowserToolbar
 ) : AccessibilityManager.TouchExplorationStateChangeListener {
+
+    private val context = appBarLayout.context
     private var isHomeVisible = false
 
-    fun init(getBrowserFragment: () -> BrowserFragment?) {
-        appBarOverlay.context.getAccessibilityManager().addTouchExplorationStateChangeListener(this)
-
-        updateCanScroll(isHomeVisible = isHomeVisible, isVoiceViewEnabled = appBarOverlay.context.isVoiceViewEnabled())
-
-        appBarOverlay.setOnClickListener {
-            appBarOverlay.visibility = View.GONE
-            getBrowserFragment()?.homeScreen?.setVisibilityWithAnimation(toShow = false)
-            TelemetryWrapper.dismissHomeOverlayClickEvent()
-        }
+    fun init() {
+        context.getAccessibilityManager().addTouchExplorationStateChangeListener(this)
+        updateCanScroll(isHomeVisible = isHomeVisible, isVoiceViewEnabled = context.isVoiceViewEnabled())
     }
 
     private fun updateCanScroll(isHomeVisible: Boolean, isVoiceViewEnabled: Boolean) {
@@ -51,16 +39,8 @@ class BrowserAppBarLayoutController(
         toolbar.setIsScrollEnabled(canScroll)
     }
 
-    fun onHomeVisibilityChange(isHomeVisible: Boolean, isHomescreenOnStartup: Boolean) {
-        // If this is the homescreen we show on startup, we want the user to be able to interact with
-        // the toolbar and be unable to dismiss the home page (which has no content behind it). If
-        // is another homescreen, we overlay the toolbar to prevent interacting with it and allow
-        // dismissing, to show the web content, when clicked.
-        val isOverlayVisible = isHomeVisible && !isHomescreenOnStartup
-        appBarOverlay.visibility = if (isOverlayVisible) View.VISIBLE else View.GONE
-        toolbar.importantForAccessibility = if (isOverlayVisible) A11Y_NO_HIDE_DESCENDANTS else A11Y_YES
-
-        updateCanScroll(isHomeVisible = isHomeVisible, isVoiceViewEnabled = appBarOverlay.context.isVoiceViewEnabled())
+    fun onHomeVisibilityChange(isHomeVisible: Boolean) {
+        updateCanScroll(isHomeVisible = isHomeVisible, isVoiceViewEnabled = context.isVoiceViewEnabled())
         this.isHomeVisible = isHomeVisible
     }
 

--- a/app/src/main/res/drawable/navigation_overlay_background.xml
+++ b/app/src/main/res/drawable/navigation_overlay_background.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <corners
+            android:topLeftRadius="40dp"
+            android:topRightRadius="40dp"/>
+
+    <solid
+            android:color="@color/photonGrey70"/>
+
+</shape>

--- a/app/src/main/res/drawable/navigation_overlay_background.xml
+++ b/app/src/main/res/drawable/navigation_overlay_background.xml
@@ -5,8 +5,8 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
 
     <corners
-            android:topLeftRadius="40dp"
-            android:topRightRadius="40dp"/>
+            android:topLeftRadius="@dimen/navigation_overlay_corner_radius"
+            android:topRightRadius="@dimen/navigation_overlay_corner_radius"/>
 
     <solid
             android:color="@color/photonGrey70"/>

--- a/app/src/main/res/drawable/navigation_overlay_background_shadow.xml
+++ b/app/src/main/res/drawable/navigation_overlay_background_shadow.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <corners
+        android:topLeftRadius="@dimen/navigation_overlay_corner_radius"
+        android:topRightRadius="@dimen/navigation_overlay_corner_radius"/>
+
+    <gradient
+            android:startColor="#55000000"
+            android:centerY="80%"
+            android:centerColor="#55000000"
+            android:endColor="@android:color/transparent"
+            android:angle="90"/>
+
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -34,22 +34,6 @@
             android:elevation="4dp" />
     </android.support.design.widget.AppBarLayout>
 
-    <!-- We want the home tiles to seem like they're above the browser content and
-         toolbar so users don't think interacting with the toolbar will affect the
-         home tiles: we use this view obscure the toolbar.
-
-         The elevation of this view must be greater than the elevation of the toolbar
-         for it to draw on top. -->
-    <View
-        android:id="@+id/appBarOverlay"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/appbar_height"
-        android:background="@color/photonGrey90_a60p"
-        android:elevation="8dp"
-        android:visibility="gone"
-        android:contentDescription="@string/nav_close_hint"
-        />
-
     <FrameLayout
         android:id="@+id/unpinOverlay"
         android:layout_width="match_parent"
@@ -66,5 +50,11 @@
             android:elevation="18dp"
             android:text="@string/homescreen_tile_remove" />
     </FrameLayout>
+
+    <FrameLayout
+            android:id="@+id/navigationOverlayContainer"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone"/>
 
 </org.mozilla.focus.TouchInterceptorLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -17,21 +17,21 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         />
 
+    <!-- Ideally, we have no elevation on the initial homescreen and elevation over web content. However, the elevation
+         over web content is broken so we set it to 0 for all cases. -->
     <android.support.design.widget.AppBarLayout
         android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="@dimen/appbar_height"
-        android:background="@color/photonGrey70">
+        android:background="@color/photonGrey70"
+        app:elevation="0dp">
 
         <!-- CoordinatorLayout scroll flags are added dynamically: see
-             BrowserAppBarLayoutController.updateCanScroll.
-
-             For elevation concerns, see appBarOverlay below. -->
+             BrowserAppBarLayoutController.updateCanScroll. -->
         <mozilla.components.browser.toolbar.BrowserToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:elevation="4dp" />
+            android:layout_height="match_parent"/>
     </android.support.design.widget.AppBarLayout>
 
     <FrameLayout

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -54,7 +54,6 @@
     <FrameLayout
             android:id="@+id/navigationOverlayContainer"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="gone"/>
+            android:layout_height="match_parent"/>
 
 </org.mozilla.focus.TouchInterceptorLayout>

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -24,20 +24,4 @@
         android:background="@android:color/black"
         android:visibility="gone" />
 
-    <!-- From our desired horizontal padding, we must subtract the "margins" introduced by
-         the extended list item width (see home_tile.xml for details).
-         At the time of writing, 44dp padding is expected on the parent and between elements.
-         Each list item adds half of this (22dp) so the parent must specify half as well (22 + 22 = 44). -->
-    <org.mozilla.focus.browser.HomeTileGridNavigation
-        android:id="@+id/homeScreen"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingStart="22dp"
-        android:paddingEnd="22dp"
-        android:paddingTop="44dp"
-        android:paddingBottom="44dp"
-        android:background="@color/browser_overlay_background"
-        android:clipChildren="false"
-        android:clipToPadding="false"
-        android:visibility="gone" />
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_navigation_overlay.xml
+++ b/app/src/main/res/layout/fragment_navigation_overlay.xml
@@ -3,21 +3,26 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<!-- This layout can be used in multiple modes: see class kdoc for details. -->
+<!-- This layout can be used in multiple modes: see class kdoc for details.
+     Adding comments to explain how these views are used is redundant to the
+     source code and liable to go out of date: however, this file is too confusing
+     without the redundant comments so we use them anyway. -->
 <android.support.constraint.ConstraintLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-    <!-- Visibility changed dynamically based on layout mode. -->
+    <!-- Visible in dialog mode, this is the semi opaque background that obscures the URL bar. -->
     <View
             android:id="@+id/semiOpaqueBackground"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:background="@color/photonGrey90_a60p"/>
 
-    <!-- The Visibility changed dynamically based on layout mode. -->
+    <!-- Visible in initial homescreen mode, this view sits below the toolbar, where the WebView
+         would be. It's only visible under the main overlay background's rounded corners. Without
+         it, the white WebView (or garbage graphics buffer) would be shown. -->
     <View
             android:id="@+id/initialHomescreenBackground"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_navigation_overlay.xml
+++ b/app/src/main/res/layout/fragment_navigation_overlay.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<!-- This layout can be used in multiple modes: see class kdoc for details. -->
+<android.support.constraint.ConstraintLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    <!-- Visibility changed dynamically based on layout mode. -->
+    <View
+            android:id="@+id/semiOpaqueBackground"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/photonGrey90_a60p"/>
+
+    <!-- marginTop changed dynamically based on layout mode.
+
+         From our desired horizontal padding, we must subtract the "margins" introduced by
+         the extended list item width (see home_tile.xml for details).
+         At the time of writing, 44dp padding is expected on the parent and between elements.
+         Each list item adds half of this (22dp) so the parent must specify half as well (22 + 22 = 44). -->
+    <org.mozilla.focus.browser.HomeTileGridNavigation
+            android:id="@+id/homeTiles"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            android:paddingStart="22dp"
+            android:paddingEnd="22dp"
+            android:paddingTop="44dp"
+            android:paddingBottom="44dp"
+            android:background="@color/browser_overlay_background"
+            android:clipChildren="false"
+            android:clipToPadding="false"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_navigation_overlay.xml
+++ b/app/src/main/res/layout/fragment_navigation_overlay.xml
@@ -17,7 +17,20 @@
             android:layout_height="match_parent"
             android:background="@color/photonGrey90_a60p"/>
 
-    <!-- marginTop changed dynamically based on layout mode.
+    <View
+            android:id="@+id/backgroundView"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toTopOf="@id/homeTiles"
+            app:layout_constraintBottom_toBottomOf="@id/homeTiles"
+            app:layout_constraintStart_toStartOf="@id/homeTiles"
+            app:layout_constraintEnd_toEndOf="@id/homeTiles"
+            android:background="@color/photonGrey70"/>
+
+    <!-- This view defines the dimensions of most other views in this layout. The height constraint configuration and
+         bias changes dynamically based on mode. In dialog mode, the height will wrap this view's content: one
+         consequence is that when tiles are removed, the height of the view may change. I have not confirmed with UX if
+         this is desirable.
 
          From our desired horizontal padding, we must subtract the "margins" introduced by
          the extended list item width (see home_tile.xml for details).
@@ -26,15 +39,27 @@
     <org.mozilla.focus.browser.HomeTileGridNavigation
             android:id="@+id/homeTiles"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             android:paddingStart="22dp"
             android:paddingEnd="22dp"
             android:paddingTop="44dp"
-            android:paddingBottom="44dp"
-            android:background="@color/photonGrey70"
             android:clipChildren="false"
             android:clipToPadding="false"/>
+
+    <android.support.constraint.Guideline
+            android:id="@+id/overlayTopAsInitialHomescreen"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintGuide_begin="@dimen/appbar_height"
+            android:orientation="horizontal"/>
+
+    <android.support.constraint.Guideline
+            android:id="@+id/overlayTopAsDialog"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintGuide_begin="@dimen/navigation_overlay_bottom_as_dialog"
+            android:orientation="horizontal"/>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_navigation_overlay.xml
+++ b/app/src/main/res/layout/fragment_navigation_overlay.xml
@@ -33,7 +33,7 @@
             android:paddingEnd="22dp"
             android:paddingTop="44dp"
             android:paddingBottom="44dp"
-            android:background="@color/browser_overlay_background"
+            android:background="@color/photonGrey70"
             android:clipChildren="false"
             android:clipToPadding="false"/>
 

--- a/app/src/main/res/layout/fragment_navigation_overlay.xml
+++ b/app/src/main/res/layout/fragment_navigation_overlay.xml
@@ -27,6 +27,32 @@
             app:layout_constraintStart_toStartOf="parent"
             android:background="@color/photonGrey70"/>
 
+    <!-- Android's elevation only creates shadows facing downward so we create our own upward facing shadow,
+         inspired by https://stackoverflow.com/a/41651284.
+
+         The height must be tuned such that it is large enough that the bottom of this view is not visible and that
+         the gradient fades at the correct speed.
+
+         This shadow is not to spec: creating a shadow that has an equal drop off on corners and the top edge is
+         complex. The current implementation was created to be good enough with much trial and error. -->
+    <View
+            android:id="@+id/backgroundShadowView"
+            android:layout_height="48dp"
+            android:layout_width="0dp"
+            app:layout_constraintTop_toTopOf="@id/backgroundShadowOffset"
+            app:layout_constraintStart_toStartOf="@id/backgroundView"
+            app:layout_constraintEnd_toEndOf="@id/backgroundView"
+            android:background="@drawable/navigation_overlay_background_shadow"/>
+
+    <!-- The height of this view determines the height of the shadow. Unfortunately, offseting a constraint
+         (constraintTop_toTopOf=backgroundView - 8dp) doesn't seem otherwise possible so we use this spacer. -->
+    <Space
+            android:id="@+id/backgroundShadowOffset"
+            android:layout_width="match_parent"
+            android:layout_height="8dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/backgroundView"/>
+
     <View
             android:id="@+id/backgroundView"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_navigation_overlay.xml
+++ b/app/src/main/res/layout/fragment_navigation_overlay.xml
@@ -17,6 +17,16 @@
             android:layout_height="match_parent"
             android:background="@color/photonGrey90_a60p"/>
 
+    <!-- The Visibility changed dynamically based on layout mode. -->
+    <View
+            android:id="@+id/initialHomescreenBackground"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toTopOf="@id/overlayTopAsInitialHomescreen"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:background="@color/photonGrey70"/>
+
     <View
             android:id="@+id/backgroundView"
             android:layout_width="0dp"
@@ -25,7 +35,7 @@
             app:layout_constraintBottom_toBottomOf="@id/homeTiles"
             app:layout_constraintStart_toStartOf="@id/homeTiles"
             app:layout_constraintEnd_toEndOf="@id/homeTiles"
-            android:background="@color/photonGrey70"/>
+            android:background="@drawable/navigation_overlay_background"/>
 
     <!-- This view defines the dimensions of most other views in this layout. The height constraint configuration and
          bias changes dynamically based on mode. In dialog mode, the height will wrap this view's content: one

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -21,8 +21,6 @@
 
     <color name="onboarding_background">#e60c0c0d</color>
 
-    <color name="browser_overlay_background">#FF38383D</color>
-
     <color name="button_highlight">#64ffffff</color>
     <color name="button_default">@color/translucent_tv_ink</color>
     <color name="button_disabled">@color/tv_ink</color>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -7,6 +7,8 @@
     <dimen name="appbar_height">104dp</dimen>
     <dimen name="navigation_overlay_bottom_as_dialog">72dp</dimen>
 
+    <dimen name="navigation_overlay_corner_radius">40dp</dimen>
+
     <!-- We specifically want match_parent here. If we set -1, the build breaks since integers aren't allowed.
          If we set -1dp, the UI breaks (i.e. we don't get match_parent). For some reason adding another
          redirection via an existing attribute works... -->

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,6 +5,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <dimen name="appbar_height">104dp</dimen>
+    <dimen name="navigation_overlay_bottom_as_dialog">72dp</dimen>
 
     <!-- We specifically want match_parent here. If we set -1, the build breaks since integers aren't allowed.
          If we set -1dp, the UI breaks (i.e. we don't get match_parent). For some reason adding another


### PR DESCRIPTION
Reviewers:
- @Baron-Severin please review whole thing
- @liuche Please review telemetry. Probes did not change but probe code moved in the refactor: I don't think it needs a real telemetry review but pinging you just in case :)

Updates the navigation overlay appearance:
![vista_motion_sensor](https://user-images.githubusercontent.com/759372/50569624-a29eb200-0d1e-11e9-8d45-cdc741ab9bdd.jpg)

I mean:
![screenshot_1546304993](https://user-images.githubusercontent.com/759372/50569635-f9a48700-0d1e-11e9-8a8a-10084170ca69.png)
![screenshot_1546305003](https://user-images.githubusercontent.com/759372/50569636-fb6e4a80-0d1e-11e9-96f1-a021aa9c93cd.png)
![screenshot_1546304929](https://user-images.githubusercontent.com/759372/50569630-d7126e00-0d1e-11e9-9678-9331f3001362.png)

Still TODO in follow-up PRs:
- Ensure acceptable performance on device
- Tweak animation params
- Verify a11y behavior
- Handle no home tiles case
- Write test for state restoration
- Consider cleaning up shadow: currently, it's not to spec in that the gradient is darker on the sides of the view than on the top

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - This PR has been going on too long and needs to land. Tests will follow-up
- [x] This PR includes a **CHANGELOG entry** or does not need one