### PR TITLE
Issue #117: add test UI infrastructure, robots, UnpinTilesTest

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,7 @@ android {
         // override this with a generated versionCode at build time.
         versionName "1.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments clearPackageData: 'true'
 
         multiDexEnabled true
     }

--- a/app/src/androidTest/java/org/mozilla/focus/helpers/MainActivityTestRule.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/helpers/MainActivityTestRule.kt
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.helpers
+
+import android.support.test.espresso.IdlingRegistry
+import android.support.test.rule.ActivityTestRule
+import org.mozilla.focus.MainActivity
+
+/**
+ * A [org.junit.Rule] to handle shared test set up for tests on [MainActivity].
+ *
+ * @param initialTouchMode See [ActivityTestRule]
+ * @param launchActivity See [ActivityTestRule]
+ * @param skipOnboarding true to skip the onboarding screen, false otherwise
+ */
+class MainActivityTestRule(
+    initialTouchMode: Boolean = false,
+    launchActivity: Boolean = true
+) : ActivityTestRule<MainActivity>(MainActivity::class.java, initialTouchMode, launchActivity) {
+
+    /**
+     * Ensures the test doesn't advance until session page load is completed.
+     *
+     * N.B.: in the current implementation, tests pass without this so it seems to be
+     * unnecessary: I think this is because the progress bar animation acts as the
+     * necessary idling resource. However, we leave this in just in case the
+     * implementation changes and the tests break. In that case, this code might be
+     * broken because it's not used, and thus tested, at present.
+     */
+    private lateinit var loadingIdlingResource: SessionLoadedIdlingResource
+
+    override fun beforeActivityLaunched() {
+        loadingIdlingResource = SessionLoadedIdlingResource().also {
+            IdlingRegistry.getInstance().register(it)
+        }
+    }
+
+    override fun afterActivityFinished() {
+        IdlingRegistry.getInstance().unregister(loadingIdlingResource)
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/focus/helpers/Matchers.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/helpers/Matchers.kt
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.helpers
+
+import android.support.test.espresso.matcher.BoundedMatcher
+import android.support.v7.widget.RecyclerView
+import android.view.View
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import android.support.test.espresso.matcher.ViewMatchers.isDisplayed as espressoIsDisplayed
+
+// TODO: replace with components implementation: #155.
+
+/**
+ * The [espressoIsDisplayed] function that can also handle unchecked state through the boolean argument.
+ */
+fun isDisplayed(isDisplayed: Boolean): Matcher<View> = maybeInvertMatcher(espressoIsDisplayed(), isDisplayed)
+
+private fun maybeInvertMatcher(matcher: Matcher<View>, useUnmodifiedMatcher: Boolean): Matcher<View> = when {
+    useUnmodifiedMatcher -> matcher
+    else -> not(matcher)
+}
+
+/**
+ * Asserts the RecyclerView has the given item count.
+ *
+ * via https://stackoverflow.com/a/50130818
+ */
+fun hasItemCount(count: Int): Matcher<View> = object : BoundedMatcher<View, RecyclerView>(RecyclerView::class.java) {
+    override fun describeTo(description: Description?) {
+        description?.appendText("has $count items")
+    }
+
+    override fun matchesSafely(view: RecyclerView?): Boolean = view?.adapter?.itemCount == count
+}

--- a/app/src/androidTest/java/org/mozilla/focus/ui/UnpinTilesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/ui/UnpinTilesTest.kt
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.ui
+
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.focus.helpers.MainActivityTestRule
+import org.mozilla.focus.ui.robots.navigationOverlay
+
+/**
+ * This test verifies the unpin tile behavior.
+ */
+class UnpinTilesTest {
+
+    @JvmField @Rule
+    val activityTestRule = MainActivityTestRule()
+
+    /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unreadable grouping.
+    @Test
+    fun unpinTilesTest() {
+        navigationOverlay {
+            assertHomeTileCount(3)
+
+        }.longPressTileToUnpinOverlay(2) {
+        }.unpinTileToNavigationOverlay {
+            assertHomeTileCount(2)
+
+        }.longPressTileIsNoOp(0) {
+            // Long pressing the google search tile is a no-op so it cannot be removed. WE RELY ON THIS BEHAVIOR:
+            // the navigation overlay does not visually handle the case when all of the home tiles are removed.
+            // If this behavior changes, this test should fail and you should also fix the navigation overlay.
+            assertHomeTileCount(2)
+        }
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/focus/ui/robots/NavigationOverlayRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/ui/robots/NavigationOverlayRobot.kt
@@ -27,7 +27,7 @@ class NavigationOverlayRobot private constructor() {
         homeTiles().check(matches(isDisplayed(isDisplayed)))
     }
 
-    class Transition {
+    inner class Transition {
 
         /**
          * Long presses the tile at the given index and returns the same screen: the Google search tile cannot be
@@ -35,11 +35,13 @@ class NavigationOverlayRobot private constructor() {
          */
         fun longPressTileIsNoOp(index: Int, interact: NavigationOverlayRobot.() -> Unit): NavigationOverlayRobot.Transition {
             longPressTile(index)
+            assertIsDisplayed()
             return NavigationOverlayRobot.interactAndTransition(interact)
         }
 
         fun longPressTileToUnpinOverlay(index: Int, interact: UnpinOverlayRobot.() -> Unit): UnpinOverlayRobot.Transition {
             longPressTile(index)
+            assertIsDisplayed()
             return UnpinOverlayRobot.interactAndTransition(interact)
         }
 
@@ -55,7 +57,7 @@ class NavigationOverlayRobot private constructor() {
                 assertIsDisplayed()
                 interact()
             }
-            return NavigationOverlayRobot.Transition()
+            return NavigationOverlayRobot().Transition()
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/focus/ui/robots/NavigationOverlayRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/ui/robots/NavigationOverlayRobot.kt
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.ui.robots
+
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.action.ViewActions
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.contrib.RecyclerViewActions
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import android.support.v7.widget.RecyclerView
+import org.mozilla.focus.R
+import org.mozilla.focus.helpers.hasItemCount
+import org.mozilla.focus.helpers.isDisplayed
+
+/**
+ * Implementation of Robot Pattern for the navigation overlay.
+ */
+class NavigationOverlayRobot private constructor() {
+
+    fun assertHomeTileCount(count: Int) {
+        homeTiles().check(matches(hasItemCount(count)))
+    }
+
+    private fun assertIsDisplayed(isDisplayed: Boolean = true) {
+        homeTiles().check(matches(isDisplayed(isDisplayed)))
+    }
+
+    class Transition {
+
+        /**
+         * Long presses the tile at the given index and returns the same screen: the Google search tile cannot be
+         * removed and long presses on that tile can be represented by this call.
+         */
+        fun longPressTileIsNoOp(index: Int, interact: NavigationOverlayRobot.() -> Unit): NavigationOverlayRobot.Transition {
+            longPressTile(index)
+            return NavigationOverlayRobot.interactAndTransition(interact)
+        }
+
+        fun longPressTileToUnpinOverlay(index: Int, interact: UnpinOverlayRobot.() -> Unit): UnpinOverlayRobot.Transition {
+            longPressTile(index)
+            return UnpinOverlayRobot.interactAndTransition(interact)
+        }
+
+        private fun longPressTile(index: Int) {
+            homeTiles().perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(index, ViewActions.longClick()))
+        }
+    }
+
+    companion object {
+
+        fun interactAndTransition(interact: NavigationOverlayRobot.() -> Unit): NavigationOverlayRobot.Transition {
+            NavigationOverlayRobot().run {
+                assertIsDisplayed()
+                interact()
+            }
+            return NavigationOverlayRobot.Transition()
+        }
+    }
+}
+
+private fun homeTiles() = onView(withId(R.id.homeTiles))
+
+/**
+ * Applies [interact] to a new [NavigationOverlayRobot]
+ *
+ * @sample org.mozilla.focus.ui.UnpinTilesTest.unpinTilesTest
+ */
+fun navigationOverlay(interact: NavigationOverlayRobot.() -> Unit): NavigationOverlayRobot.Transition {
+    return NavigationOverlayRobot.interactAndTransition(interact)
+}

--- a/app/src/androidTest/java/org/mozilla/focus/ui/robots/UnpinOverlayRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/ui/robots/UnpinOverlayRobot.kt
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.ui.robots
+
+import android.support.test.espresso.Espresso.onView
+import android.support.test.espresso.action.ViewActions.click
+import android.support.test.espresso.assertion.ViewAssertions.matches
+import android.support.test.espresso.matcher.ViewMatchers.withId
+import org.mozilla.focus.R
+import org.mozilla.focus.helpers.isDisplayed
+
+/**
+ * Implementation of Robot Pattern for the home tile unpin overlay.
+ */
+class UnpinOverlayRobot private constructor() {
+
+    private fun assertIsDisplayed(isDisplayed: Boolean = true) {
+        unpinButton().check(matches(isDisplayed(isDisplayed)))
+    }
+
+    class Transition {
+
+        fun unpinTileToNavigationOverlay(interact: NavigationOverlayRobot.() -> Unit): NavigationOverlayRobot.Transition {
+            unpinButton().perform(click())
+            return NavigationOverlayRobot.interactAndTransition(interact)
+        }
+
+        @Suppress("UNUSED_PARAMETER") // TODO: remove when fixing this method.
+        fun dismissToNavigationOverlay(interact: NavigationOverlayRobot.() -> Unit): NavigationOverlayRobot.Transition {
+            throw NotImplementedError("TODO: fix this method. the simple implementation clicks the center of the " +
+                "overlay, i.e. the remove button, and does not dismiss without removing")
+//            semiOpaqueOverlay().perform(click())
+//            return NavigationOverlayRobot.interactAndTransition(interact)
+        }
+    }
+
+    companion object {
+        fun interactAndTransition(interact: UnpinOverlayRobot.() -> Unit): UnpinOverlayRobot.Transition {
+            UnpinOverlayRobot().run {
+                assertIsDisplayed()
+                interact()
+            }
+            return UnpinOverlayRobot.Transition()
+        }
+    }
+}
+
+private fun unpinButton() = onView(withId(R.id.unpinButton))
+private fun semiOpaqueOverlay() = onView(withId(R.id.unpinOverlay))

--- a/app/src/androidTest/java/org/mozilla/focus/ui/robots/UnpinOverlayRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/focus/ui/robots/UnpinOverlayRobot.kt
@@ -20,10 +20,11 @@ class UnpinOverlayRobot private constructor() {
         unpinButton().check(matches(isDisplayed(isDisplayed)))
     }
 
-    class Transition {
+    inner class Transition {
 
         fun unpinTileToNavigationOverlay(interact: NavigationOverlayRobot.() -> Unit): NavigationOverlayRobot.Transition {
             unpinButton().perform(click())
+            assertIsDisplayed(false)
             return NavigationOverlayRobot.interactAndTransition(interact)
         }
 
@@ -32,6 +33,7 @@ class UnpinOverlayRobot private constructor() {
             throw NotImplementedError("TODO: fix this method. the simple implementation clicks the center of the " +
                 "overlay, i.e. the remove button, and does not dismiss without removing")
 //            semiOpaqueOverlay().perform(click())
+//            assertIsDisplayed(false)
 //            return NavigationOverlayRobot.interactAndTransition(interact)
         }
     }
@@ -42,7 +44,7 @@ class UnpinOverlayRobot private constructor() {
                 assertIsDisplayed()
                 interact()
             }
-            return UnpinOverlayRobot.Transition()
+            return UnpinOverlayRobot().Transition()
         }
     }
 }


### PR DESCRIPTION
**Review #154 first: that is the initial implementation**.

I wanted to write a test to ensure we can't remove all of the home tiles
because I don't handle that case in the navigation overlay. While I was in the
area, I made the test handle unpinning in a variety of cases.

This is unlikely to be all of the test code added for this issue.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
