### PR TITLE
Closes #161: Change max nav overlay expansion to 128dp.

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,7 +5,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
 
     <dimen name="appbar_height">104dp</dimen>
-    <dimen name="navigation_overlay_bottom_as_dialog">72dp</dimen>
+    <dimen name="navigation_overlay_bottom_as_dialog">128dp</dimen>
 
     <dimen name="navigation_overlay_corner_radius">40dp</dimen>
 


### PR DESCRIPTION
The overlay was too close to the top of the screen, making it hard to
dismiss and, after we implement swipe-to-close, making it easy to
trigger the system notification tray instead of swipe-to-close.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - Small UI change
- [x] This PR includes a **CHANGELOG entry** or does not need one
  - Unreleased
