### PR TITLE
Closes #167: Call missing listener on nav overlay vis change; move to ViewModel

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -152,6 +152,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation "org.robolectric:robolectric:3.8"
     testImplementation 'org.mockito:mockito-core:2.21.0'
+    testImplementation "android.arch.core:core-testing:1.1.1"
 
     androidTestImplementation 'com.android.support.test.uiautomator:uiautomator-v18:2.1.3'
 

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -91,7 +91,7 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
     private fun initViews() {
         ViewModelProviders.of(this)[BrowserAppBarViewModel::class.java].let { viewModel ->
             appBarLayoutController = BrowserAppBarLayoutController(viewModel, appBarLayout, toolbar).apply {
-                init(lifecycle, this@MainActivity)
+                init(this@MainActivity)
             }
         }
     }

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -5,6 +5,7 @@
 
 package org.mozilla.focus
 
+import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -32,6 +33,7 @@ import org.mozilla.focus.settings.UserClearDataEventObserver
 import org.mozilla.focus.telemetry.SentryWrapper
 import org.mozilla.focus.telemetry.TelemetryWrapper
 import org.mozilla.focus.toolbar.BrowserAppBarLayoutController
+import org.mozilla.focus.toolbar.BrowserAppBarViewModel
 import org.mozilla.focus.toolbar.ToolbarCallbacks
 import org.mozilla.focus.toolbar.ToolbarEvent
 import org.mozilla.focus.toolbar.ToolbarIntegration
@@ -87,8 +89,10 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
     }
 
     private fun initViews() {
-        appBarLayoutController = BrowserAppBarLayoutController(appBarLayout, toolbar).apply {
-            init(lifecycle)
+        ViewModelProviders.of(this)[BrowserAppBarViewModel::class.java].let { viewModel ->
+            appBarLayoutController = BrowserAppBarLayoutController(viewModel, appBarLayout, toolbar).apply {
+                init(lifecycle, this@MainActivity)
+            }
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -162,8 +162,9 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
         }
     }
 
-    override fun onHomeVisibilityChange(isHomeVisible: Boolean, isHomescreenOnStartup: Boolean) {
-        appBarLayoutController.onHomeVisibilityChange(isHomeVisible)
+    override fun setNavigationOverlayIsVisible(isVisible: Boolean, isOverlayOnStartup: Boolean) {
+        ScreenController.setNavigationOverlayIsVisible(supportFragmentManager, appBarLayoutController,
+            isVisible = isVisible, isOverlayOnStartup = isOverlayOnStartup)
     }
 
     override fun onFullScreenChange(isFullscreen: Boolean) {

--- a/app/src/main/java/org/mozilla/focus/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/focus/ScreenController.kt
@@ -6,7 +6,6 @@
 package org.mozilla.focus
 
 import android.content.Context
-import android.support.design.widget.AppBarLayout
 import android.support.v4.app.FragmentManager
 import android.text.TextUtils
 import org.mozilla.focus.browser.BrowserFragment
@@ -113,7 +112,7 @@ object ScreenController {
                 throw IllegalStateException("Did not expect navigation overlay to exist")
             }
 
-            val newOverlay = NavigationOverlayFragment.newInstance(isInitialHomescreen = isOverlayOnStartup)
+            val newOverlay = NavigationOverlayFragment.newInstance(isOverlayOnStartup = isOverlayOnStartup)
             fragmentManager.beginTransaction()
                 .replace(R.id.navigationOverlayContainer, newOverlay, NavigationOverlayFragment.FRAGMENT_TAG)
                 .commit()

--- a/app/src/main/java/org/mozilla/focus/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/focus/ScreenController.kt
@@ -118,9 +118,8 @@ object ScreenController {
                 .replace(R.id.navigationOverlayContainer, newOverlay, NavigationOverlayFragment.FRAGMENT_TAG)
                 .commit()
         } else {
-            // todo: get if current state is initial homescreen or not for animation out.
             val existingOverlay = getNavOverlay()!!
-            NavigationOverlayAnimations.animateOut(existingOverlay.view!!, isInitialHomescreen = false) {
+            NavigationOverlayAnimations.animateOut(existingOverlay) {
                 fragmentManager.beginTransaction()
                     .remove(existingOverlay)
                     .commit()

--- a/app/src/main/java/org/mozilla/focus/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/focus/ScreenController.kt
@@ -99,6 +99,12 @@ object ScreenController {
         SessionManager.getInstance().removeAllSessions()
     }
 
+    /**
+     * Sets the navigation overlay visibility based on the given params.
+     *
+     * This method will throw if this method is called to set the nav overlay visible
+     * but it is already visible and vice versa.
+     */
     fun setNavigationOverlayIsVisible(
         fragmentManager: FragmentManager,
         appBarLayoutController: BrowserAppBarLayoutController,
@@ -117,7 +123,7 @@ object ScreenController {
                 .replace(R.id.navigationOverlayContainer, newOverlay, NavigationOverlayFragment.FRAGMENT_TAG)
                 .commit()
         } else {
-            val existingOverlay = getNavOverlay()!!
+            val existingOverlay = getNavOverlay() ?: throw IllegalStateException("Expected navigation overlay to exist")
             NavigationOverlayAnimations.animateOut(existingOverlay) {
                 fragmentManager.beginTransaction()
                     .remove(existingOverlay)

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayAnimations.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayAnimations.kt
@@ -33,8 +33,8 @@ object NavigationOverlayAnimations {
         }
     }
 
-    fun animateOut(overlay: View, isInitialHomescreen: Boolean, onAnimationEnd: () -> Unit) {
-        getAnimator(overlay, isAnimateIn = false, isInitialHomescreen = isInitialHomescreen, onAnimationEnd = onAnimationEnd)
+    fun animateOut(overlay: NavigationOverlayFragment, onAnimationEnd: () -> Unit) {
+        getAnimator(overlay.view!!, isAnimateIn = false, isInitialHomescreen = overlay.isInitialHomescreen, onAnimationEnd = onAnimationEnd)
             .start()
     }
 

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayAnimations.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayAnimations.kt
@@ -21,8 +21,8 @@ private const val TRANSLATION_MILLIS_FOR_FULL_SCREEN = 400
  */
 object NavigationOverlayAnimations {
 
-    fun onCreateViewAnimateIn(overlay: View, isInitialHomescreen: Boolean, isBeingRestored: Boolean, onAnimationEnd: () -> Unit) {
-        if (isInitialHomescreen || isBeingRestored) {
+    fun onCreateViewAnimateIn(overlay: View, isOverlayOnStartup: Boolean, isBeingRestored: Boolean, onAnimationEnd: () -> Unit) {
+        if (isOverlayOnStartup || isBeingRestored) {
             onAnimationEnd()
             return
         }
@@ -34,7 +34,7 @@ object NavigationOverlayAnimations {
     }
 
     fun animateOut(overlay: NavigationOverlayFragment, onAnimationEnd: () -> Unit) {
-        getAnimator(overlay.view!!, isAnimateIn = false, isInitialHomescreen = overlay.isInitialHomescreen, onAnimationEnd = onAnimationEnd)
+        getAnimator(overlay.view!!, isAnimateIn = false, isOverlayOnStartup = overlay.isOverlayOnStartup, onAnimationEnd = onAnimationEnd)
             .start()
     }
 
@@ -42,7 +42,7 @@ object NavigationOverlayAnimations {
     private fun getAnimator(
         overlay: View,
         isAnimateIn: Boolean,
-        isInitialHomescreen: Boolean = false,
+        isOverlayOnStartup: Boolean = false,
         onAnimationEnd: () -> Unit
     ): Animator {
         fun getAnimationDuration(): Long {
@@ -65,7 +65,7 @@ object NavigationOverlayAnimations {
             interpolator = alphaInterpolator
         }
 
-        val initialHomescreenBackgroundAnimator = if (!isInitialHomescreen) {
+        val initialHomescreenBackgroundAnimator = if (!isOverlayOnStartup) {
             null
         } else {
             ObjectAnimator.ofFloat(overlay.initialHomescreenBackground, "alpha", 1f, 0f).apply {

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
@@ -24,7 +24,7 @@ import org.mozilla.focus.browser.HomeTileLongClickListener
 import org.mozilla.focus.ext.updateLayoutParams
 import org.mozilla.focus.telemetry.TelemetryWrapper
 
-private const val KEY_IS_INITIAL_HOMESCREEN = "isInitialHomescreen"
+private const val KEY_IS_OVERLAY_ON_STARTUP = "isOverlayOnStartup"
 
 /**
  * An overlay that allows the user to navigate to new pages including via the home tiles. The overlay
@@ -37,20 +37,20 @@ private const val KEY_IS_INITIAL_HOMESCREEN = "isInitialHomescreen"
  */
 class NavigationOverlayFragment : Fragment() {
 
-    val isInitialHomescreen: Boolean by lazy { arguments!!.getBoolean(KEY_IS_INITIAL_HOMESCREEN) }
+    val isOverlayOnStartup: Boolean by lazy { arguments!!.getBoolean(KEY_IS_OVERLAY_ON_STARTUP) }
 
     private val callbacks: BrowserFragmentCallbacks? get() = activity as BrowserFragmentCallbacks?
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val overlay = inflater.inflate(R.layout.fragment_navigation_overlay, container, false)
 
-        overlay.semiOpaqueBackground.visibility = if (isInitialHomescreen) View.GONE else View.VISIBLE
-        overlay.initialHomescreenBackground.visibility = if (isInitialHomescreen) View.VISIBLE else View.GONE
+        overlay.semiOpaqueBackground.visibility = if (isOverlayOnStartup) View.GONE else View.VISIBLE
+        overlay.initialHomescreenBackground.visibility = if (isOverlayOnStartup) View.VISIBLE else View.GONE
         overlay.homeTiles.urlSearcher = activity as UrlSearcher
 
         setOverlayHeight(overlay.homeTiles)
 
-        NavigationOverlayAnimations.onCreateViewAnimateIn(overlay, isInitialHomescreen, isBeingRestored = savedInstanceState != null) {
+        NavigationOverlayAnimations.onCreateViewAnimateIn(overlay, isOverlayOnStartup, isBeingRestored = savedInstanceState != null) {
             // We defer setting click listeners until the animation completes
             // so the animation will not be interrupted.
             setOnClickListeners(overlay)
@@ -73,7 +73,7 @@ class NavigationOverlayFragment : Fragment() {
             val verticalBias: Float
             val heightConstraintType: Int
             @IdRes val topToBottom: Int
-            if (isInitialHomescreen) {
+            if (isOverlayOnStartup) {
                 // Fill constraints from top to bottom (app bar to bottom of screen).
                 verticalBias = 0f
                 heightConstraintType = MATCH_CONSTRAINT_SPREAD
@@ -134,9 +134,9 @@ class NavigationOverlayFragment : Fragment() {
     companion object {
         const val FRAGMENT_TAG = "navOverlay"
 
-        fun newInstance(isInitialHomescreen: Boolean) = NavigationOverlayFragment().apply {
+        fun newInstance(isOverlayOnStartup: Boolean) = NavigationOverlayFragment().apply {
             arguments = Bundle().apply {
-                putBoolean(KEY_IS_INITIAL_HOMESCREEN, isInitialHomescreen)
+                putBoolean(KEY_IS_OVERLAY_ON_STARTUP, isOverlayOnStartup)
             }
         }
     }

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
@@ -10,7 +10,6 @@ import android.support.constraint.ConstraintLayout
 import android.support.constraint.ConstraintLayout.LayoutParams.MATCH_CONSTRAINT_SPREAD
 import android.support.constraint.ConstraintLayout.LayoutParams.MATCH_CONSTRAINT_WRAP
 import android.support.v4.app.Fragment
-import android.support.v4.app.FragmentManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -106,7 +105,7 @@ class NavigationOverlayFragment : Fragment() {
 
         overlay.semiOpaqueBackground.setOnClickListener {
             removeClickListeners()
-            dismiss()
+            callbacks?.setNavigationOverlayIsVisible(false)
             TelemetryWrapper.dismissHomeOverlayClickEvent()
         }
 
@@ -121,20 +120,6 @@ class NavigationOverlayFragment : Fragment() {
                     callbacks?.onHomeTileLongClick(unpinTile)
                 }
             }
-        }
-    }
-
-    fun show(fragmentManager: FragmentManager) {
-        fragmentManager.beginTransaction()
-            .replace(R.id.navigationOverlayContainer, this, FRAGMENT_TAG)
-            .commit()
-    }
-
-    fun dismiss() {
-        NavigationOverlayAnimations.animateOut(view!!, isInitialHomescreen) {
-            fragmentManager!!.beginTransaction()
-                .remove(this)
-                .commit()
         }
     }
 

--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
@@ -37,7 +37,7 @@ private const val KEY_IS_INITIAL_HOMESCREEN = "isInitialHomescreen"
  */
 class NavigationOverlayFragment : Fragment() {
 
-    private val isInitialHomescreen: Boolean by lazy { arguments!!.getBoolean(KEY_IS_INITIAL_HOMESCREEN) }
+    val isInitialHomescreen: Boolean by lazy { arguments!!.getBoolean(KEY_IS_INITIAL_HOMESCREEN) }
 
     private val callbacks: BrowserFragmentCallbacks? get() = activity as BrowserFragmentCallbacks?
 

--- a/app/src/main/java/org/mozilla/focus/toolbar/BrowserAppBarLayoutController.kt
+++ b/app/src/main/java/org/mozilla/focus/toolbar/BrowserAppBarLayoutController.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.focus.toolbar
 
-import android.arch.lifecycle.Lifecycle
 import android.arch.lifecycle.Lifecycle.Event.ON_START
 import android.arch.lifecycle.Lifecycle.Event.ON_STOP
 import android.arch.lifecycle.LifecycleObserver
@@ -38,8 +37,8 @@ class BrowserAppBarLayoutController(
 
     private val context = appBarLayout.context
 
-    fun init(lifecycle: Lifecycle, lifecycleOwner: LifecycleOwner) {
-        lifecycle.addObserver(this)
+    fun init(lifecycleOwner: LifecycleOwner) {
+        lifecycleOwner.lifecycle.addObserver(this)
         viewModel.isToolbarScrollEnabled.observe(lifecycleOwner, Observer {
             toolbar.setIsScrollEnabled(it!!)
         })

--- a/app/src/main/java/org/mozilla/focus/toolbar/BrowserAppBarViewModel.kt
+++ b/app/src/main/java/org/mozilla/focus/toolbar/BrowserAppBarViewModel.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.toolbar
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.ViewModel
+import android.support.annotation.UiThread
+import kotlin.properties.ObservableProperty
+import kotlin.reflect.KProperty
+
+/**
+ * The view state, and UI event callbacks, for the app bar layout.
+ */
+class BrowserAppBarViewModel : ViewModel() {
+
+    private var _isToolbarScrollEnabled = MutableLiveData<Boolean>()
+    val isToolbarScrollEnabled: LiveData<Boolean> = _isToolbarScrollEnabled
+
+    // The initial values are unimportant because they're immediately updated.
+    // TODO: these properties should be reactively pushed from the model.
+    private var isNavigationOverlayVisible: Boolean by ToolbarScrollAffectingProperty(false)
+    private var isVoiceViewEnabled: Boolean by ToolbarScrollAffectingProperty(false)
+
+    @UiThread
+    fun setIsNavigationOverlayVisible(isVisible: Boolean) {
+        isNavigationOverlayVisible = isVisible
+    }
+
+    @UiThread
+    fun setIsVoiceViewEnabled(isEnabled: Boolean) {
+        isVoiceViewEnabled = isEnabled
+    }
+
+    /**
+     * A delegated property to be used for properties whose value affect the [isToolbarScrollEnabled] property.
+     * This is used to reduce code duplication over multiple observables.
+     */
+    private inner class ToolbarScrollAffectingProperty(initialValue: Boolean) : ObservableProperty<Boolean>(initialValue) {
+        override fun afterChange(property: KProperty<*>, oldValue: Boolean, newValue: Boolean) {
+            // For simplicity, update on the UI thread. This property affects UI so it should be UI thread anyway.
+            _isToolbarScrollEnabled.value = !isNavigationOverlayVisible && !isVoiceViewEnabled
+        }
+    }
+}

--- a/app/src/test/java/org/mozilla/focus/helpers/ext/LiveDataTestHelper.kt
+++ b/app/src/test/java/org/mozilla/focus/helpers/ext/LiveDataTestHelper.kt
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.helpers.ext
+
+import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.Observer
+import org.junit.Assert.fail
+import org.mockito.Mockito.any
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+
+fun <T> LiveData<T>.assertThat(vararg predicates: (T) -> Boolean, pushValues: () -> Unit) {
+    val (actualValues, observer) = collectEmissions(this, pushValues)
+
+    if (actualValues.size > predicates.size) fail("LiveData emitted more values than expected\nExpected: ${predicates.size}\nActual  : $actualValues")
+    if (actualValues.size < predicates.size) fail("LiveData emitted fewer values than expected\nExpected: ${predicates.size}\nActual  : $actualValues")
+
+    predicates.zip(actualValues).forEachIndexed { i, (predicate, actual) ->
+        if (!predicate.invoke(actual)) fail("Value emitted at index $i does satisfy predicate.\nExpected: true\nActual: false")
+    }
+
+    verify(observer, times(predicates.size)).onChanged(any())
+}
+
+fun <T> LiveData<T>.assertValues(vararg expectedRaw: T, pushValues: () -> Unit) {
+    // Arrays do not print prettily, so convert them to a list
+    val expectedValues = List(expectedRaw.size) { expectedRaw[it] }
+
+    val (actualValues, observer) = collectEmissions(this, pushValues)
+
+    if (actualValues.size > expectedValues.size) fail("LiveData emitted more values than expected\nExpected: $expectedValues\nActual  : $actualValues")
+    if (actualValues.size < expectedValues.size) fail("LiveData emitted fewer values than expected\nExpected: $expectedValues\nActual  : $actualValues")
+
+    expectedValues.zip(actualValues).forEachIndexed { i, (expect, actual) ->
+        if (expect != actual) fail("Values emitted at index $i do not match\nExpected: $expectedValues\nActual  : $actualValues")
+    }
+
+    verify(observer, times(expectedValues.size)).onChanged(any())
+}
+
+private fun <T> collectEmissions(liveData: LiveData<T>, pushValues: () -> Unit): Pair<List<T>, Observer<T>> {
+    val actualValues = mutableListOf<T>()
+
+    val observer = spy(Observer<T> {
+        it ?: return@Observer
+        actualValues += it
+    })
+
+    liveData.observeForever(observer)
+    pushValues.invoke()
+    return actualValues to observer
+}
+
+fun <T> MutableLiveData<T>.assertValuesWithReceiver(vararg expectedRaw: T, pushValues: MutableLiveData<T>.() -> Unit) {
+    this.assertValues(*expectedRaw) { this.pushValues() }
+}

--- a/app/src/test/java/org/mozilla/focus/helpers/ext/LiveDataTestHelperTest.kt
+++ b/app/src/test/java/org/mozilla/focus/helpers/ext/LiveDataTestHelperTest.kt
@@ -1,0 +1,161 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.helpers.ext
+
+import android.arch.core.executor.testing.InstantTaskExecutorRule
+import android.arch.lifecycle.MutableLiveData
+import org.junit.Rule
+import org.junit.Test
+
+class LiveDataTestHelperTest {
+
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    @Test(expected = AssertionError::class)
+    fun `GIVEN assertValues WHEN actual list is too short THEN test fails`() {
+        val ld = MutableLiveData<Int>()
+        ld.assertValues(1, 2, 3, 4) {
+            ld.value = 1
+            ld.value = 2
+            ld.value = 3
+        }
+    }
+
+    @Test(expected = AssertionError::class)
+    fun `GIVEN assertValuesWithReceiver WHEN actual list is too short THEN test fails`() {
+        MutableLiveData<Int>().assertValuesWithReceiver(1, 2, 3, 4) {
+            value = 1
+            value = 2
+            value = 3
+        }
+    }
+
+    @Test(expected = AssertionError::class)
+    fun `GIVEN assertThat WHEN actual list is too short THEN test fails`() {
+        val ld = MutableLiveData<Int>()
+        ld.assertThat({ it == 1 }, { it == 2 }, { it == 3 }, { it == 4 }) {
+            ld.value = 1
+            ld.value = 2
+            ld.value = 3
+        }
+    }
+
+    @Test(expected = AssertionError::class)
+    fun `GIVEN assertValues WHEN actual list is too long THEN test fails`() {
+        val ld = MutableLiveData<Int>()
+        ld.assertValues(1, 2, 3, 4) {
+            ld.value = 1
+            ld.value = 2
+            ld.value = 3
+            ld.value = 4
+            ld.value = 5
+        }
+    }
+
+    @Test(expected = AssertionError::class)
+    fun `GIVEN assertValuesWithReceiver WHEN actual list is too long THEN test fails`() {
+        MutableLiveData<Int>().assertValuesWithReceiver(1, 2, 3, 4) {
+            value = 1
+            value = 2
+            value = 3
+            value = 4
+            value = 5
+        }
+    }
+
+    @Test(expected = AssertionError::class)
+    fun `GIVEN assertThat WHEN actual list is too long THEN test fails`() {
+        val ld = MutableLiveData<Int>()
+        ld.assertThat({ it == 1 }, { it == 2 }, { it == 3 }, { it == 4 }) {
+            ld.value = 1
+            ld.value = 2
+            ld.value = 3
+            ld.value = 4
+            ld.value = 5
+        }
+    }
+
+    @Test(expected = AssertionError::class)
+    fun `GIVEN assertValues WHEN actual list is incorrect THEN test fails`() {
+        val ld = MutableLiveData<Int>()
+        ld.assertValues(1, 2, 3, 4) {
+            ld.value = 1
+            ld.value = 3
+            ld.value = 3
+            ld.value = 4
+        }
+    }
+
+    @Test(expected = AssertionError::class)
+    fun `GIVEN assertValuesWithReceiver WHEN actual list is incorrect THEN test fails`() {
+        MutableLiveData<Int>().assertValuesWithReceiver(1, 2, 3, 4) {
+            value = 4
+            value = 2
+            value = 3
+            value = 4
+        }
+    }
+
+    @Test(expected = AssertionError::class)
+    fun `GIVEN assertThat WHEN actual list is incorrect THEN test fails`() {
+        val ld = MutableLiveData<Int>()
+        ld.assertThat({ it == 1 }, { it == 2 }, { it == 3 }, { it == 4 }) {
+            ld.value = 1
+            ld.value = 3
+            ld.value = 3
+            ld.value = 4
+        }
+    }
+
+    @Test(expected = AssertionError::class)
+    fun `GIVEN assertValues WHEN actual list is empty THEN test fails`() {
+        val ld = MutableLiveData<Int>()
+        ld.assertValues(1, 2, 3, 4) { }
+    }
+
+    @Test(expected = AssertionError::class)
+    fun `GIVEN assertValuesWithReceiver WHEN actual list is empty THEN test fails`() {
+        MutableLiveData<Int>().assertValuesWithReceiver(1, 2, 3, 4) { }
+    }
+
+    @Test(expected = AssertionError::class)
+    fun `GIVEN assertThat WHEN actual list is empty THEN test fails`() {
+        val ld = MutableLiveData<Int>()
+        ld.assertThat({ it == 1 }, { it == 2 }, { it == 3 }, { it == 4 }) {}
+    }
+
+    @Test
+    fun `GIVEN assertValues WHEN actual list is correct THEN test passes`() {
+        val ld = MutableLiveData<Int>()
+        ld.assertValues(1, 2, 3, 4) {
+            ld.value = 1
+            ld.value = 2
+            ld.value = 3
+            ld.value = 4
+        }
+    }
+
+    @Test
+    fun `GIVEN assertValuesWithReceiver WHEN actual list is correct THEN test passes`() {
+        MutableLiveData<Int>().assertValuesWithReceiver(1, 2, 3, 4) {
+            value = 1
+            value = 2
+            value = 3
+            value = 4
+        }
+    }
+
+    @Test
+    fun `GIVEN assertThat WHEN actual list is correct THEN test passes`() {
+        val ld = MutableLiveData<Int>()
+        ld.assertThat({ it == 1 }, { it == 2 }, { it == 3 }, { it == 4 }) {
+            ld.value = 1
+            ld.value = 2
+            ld.value = 3
+            ld.value = 4
+        }
+    }
+}

--- a/app/src/test/java/org/mozilla/focus/toolbar/BrowserAppBarLayoutControllerTest.kt
+++ b/app/src/test/java/org/mozilla/focus/toolbar/BrowserAppBarLayoutControllerTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.focus.toolbar
 
 import android.content.Context
@@ -36,7 +40,7 @@ class BrowserAppBarLayoutControllerTest {
             `when`(it.layoutParams).thenReturn(mock(AppBarLayout.LayoutParams::class.java))
         }
 
-        controller = BrowserAppBarLayoutController(appBarLayout, toolbar)
+        controller = BrowserAppBarLayoutController(mock(BrowserAppBarViewModel::class.java), appBarLayout, toolbar)
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/focus/toolbar/BrowserAppBarViewModelTest.kt
+++ b/app/src/test/java/org/mozilla/focus/toolbar/BrowserAppBarViewModelTest.kt
@@ -5,12 +5,11 @@
 package org.mozilla.focus.toolbar
 
 import android.arch.core.executor.testing.InstantTaskExecutorRule
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.focus.helpers.ext.assertValues
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
@@ -29,21 +28,22 @@ class BrowserAppBarViewModelTest {
     fun `GIVEN voiceView is disabled WHEN navigation overlay is visible THEN toolbar scroll is disabled`() {
         viewModel.setIsVoiceViewEnabled(false)
         viewModel.setIsNavigationOverlayVisible(true)
-        viewModel.isToolbarScrollEnabled.observeForever { assertFalse(it!!) }
+        viewModel.isToolbarScrollEnabled.assertValues(false) {}
     }
 
     @Test
     fun `GIVEN voiceView is disabled WHEN navigation overlay is not visible THEN toolbar scroll is enabled`() {
         viewModel.setIsVoiceViewEnabled(false)
         viewModel.setIsNavigationOverlayVisible(false)
-        viewModel.isToolbarScrollEnabled.observeForever { assertTrue(it!!) }
+        viewModel.isToolbarScrollEnabled.assertValues(true) {}
     }
 
     @Test
     fun `GIVEN voiceView is enabled THEN toolbar scroll is always disabled`() {
         viewModel.setIsVoiceViewEnabled(true)
         viewModel.setIsNavigationOverlayVisible(false)
-        viewModel.isToolbarScrollEnabled.observeForever { assertFalse(it!!) }
-        viewModel.setIsNavigationOverlayVisible(true)
+        viewModel.isToolbarScrollEnabled.assertValues(false, false) {
+            viewModel.setIsNavigationOverlayVisible(true)
+        }
     }
 }

--- a/app/src/test/java/org/mozilla/focus/toolbar/BrowserAppBarViewModelTest.kt
+++ b/app/src/test/java/org/mozilla/focus/toolbar/BrowserAppBarViewModelTest.kt
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.toolbar
+
+import android.arch.core.executor.testing.InstantTaskExecutorRule
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BrowserAppBarViewModelTest {
+
+    @get:Rule val instantTaskRule = InstantTaskExecutorRule() // necessary for LiveData tests.
+
+    private lateinit var viewModel: BrowserAppBarViewModel
+
+    @Before
+    fun setUp() {
+        viewModel = BrowserAppBarViewModel()
+    }
+
+    @Test
+    fun `GIVEN voiceView is disabled WHEN navigation overlay is visible THEN toolbar scroll is disabled`() {
+        viewModel.setIsVoiceViewEnabled(false)
+        viewModel.setIsNavigationOverlayVisible(true)
+        viewModel.isToolbarScrollEnabled.observeForever { assertFalse(it!!) }
+    }
+
+    @Test
+    fun `GIVEN voiceView is disabled WHEN navigation overlay is not visible THEN toolbar scroll is enabled`() {
+        viewModel.setIsVoiceViewEnabled(false)
+        viewModel.setIsNavigationOverlayVisible(false)
+        viewModel.isToolbarScrollEnabled.observeForever { assertTrue(it!!) }
+    }
+
+    @Test
+    fun `GIVEN voiceView is enabled THEN toolbar scroll is always disabled`() {
+        viewModel.setIsVoiceViewEnabled(true)
+        viewModel.setIsNavigationOverlayVisible(false)
+        viewModel.isToolbarScrollEnabled.observeForever { assertFalse(it!!) }
+        viewModel.setIsNavigationOverlayVisible(true)
+    }
+}


### PR DESCRIPTION
The first three commits fix the bug the easy way: the last two commits incrementally refactor the code to use a ViewModel (unfortunately, with a distinct model). However, moving to the ViewModel lets us easily test the code in unit tests, unlike the solution from the first three commits, and gets us closer to an eventual MVVM refactor.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
  - Unreleased bug
