### PR TITLE
Closes #111: Add readme link to security issues. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participatio
 * [Guide to Contributing][contribute] (**new contributors start here!**)
 * Open issues: https://github.com/mozilla-mobile/firefox-echo-show/issues
   * [`good first issues`][good first] | [`help wanted`][help]
-  * File a security issue: we're working on getting a space!
+  * [File a security issue][sec issue] (be sure to check "Restrict access to... 'Security-Sensitive Firefox Bug' group")
 * IRC: [#focus (irc.mozilla.org)](https://wiki.mozilla.org/IRC) | [view logs](https://mozilla.logbot.info/focus/);
 we're available Monday-Friday, GMT and PST working hours.
 * Mailing list:
@@ -85,3 +85,4 @@ See that script's source for further usage.
 [contribute]: https://github.com/mozilla-mobile/shared-docs/blob/master/android/CONTRIBUTING.md
 [good first]: https://github.com/mozilla-mobile/firefox-echo-show/labels/good%20first%20issue
 [help]: https://github.com/mozilla-mobile/firefox-echo-show/labels/help%20wanted
+[sec issue]: https://bugzilla.mozilla.org/enter_bug.cgi?assigned_to=nobody%40mozilla.org&bug_ignored=0&bug_severity=normal&bug_status=NEW&cf_fx_iteration=---&cf_fx_points=---&component=Security%3A%20General&contenttypemethod=list&contenttypeselection=text%2Fplain&flag_type-4=X&flag_type-607=X&flag_type-791=X&flag_type-800=X&flag_type-803=X&form_name=enter_bug&groups=firefox-core-security&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=Unspecified&priority=--&product=Firefox%20for%20Echo%20Show&rep_platform=Unspecified&target_milestone=---&version=unspecified


### PR DESCRIPTION
Unfortunately, the bug template doesn't seem to automatically check the
"Restrict to security bug group" checkbox, unlike Fire TV, so we have to
remind bug filers to check it manually.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - readme update
- [x] This PR includes a **CHANGELOG entry** or does not need one
