### PR TITLE
Closes #190: Don't assert nav overlay state before changing vis.

### DIFF
--- a/app/src/main/java/org/mozilla/focus/ScreenController.kt
+++ b/app/src/main/java/org/mozilla/focus/ScreenController.kt
@@ -114,20 +114,17 @@ object ScreenController {
         fun getNavOverlay() = fragmentManager.getNavigationOverlay()
 
         if (isVisible) {
-            if (getNavOverlay() != null) {
-                throw IllegalStateException("Did not expect navigation overlay to exist")
-            }
-
             val newOverlay = NavigationOverlayFragment.newInstance(isOverlayOnStartup = isOverlayOnStartup)
             fragmentManager.beginTransaction()
                 .replace(R.id.navigationOverlayContainer, newOverlay, NavigationOverlayFragment.FRAGMENT_TAG)
                 .commit()
         } else {
-            val existingOverlay = getNavOverlay() ?: throw IllegalStateException("Expected navigation overlay to exist")
-            NavigationOverlayAnimations.animateOut(existingOverlay) {
-                fragmentManager.beginTransaction()
-                    .remove(existingOverlay)
-                    .commit()
+            getNavOverlay()?.let { existingOverlay ->
+                NavigationOverlayAnimations.animateOut(existingOverlay) {
+                    fragmentManager.beginTransaction()
+                        .remove(existingOverlay)
+                        .commit()
+                }
             }
         }
 


### PR DESCRIPTION
The assertion was causing the crash.

I noticed the current code is not explicit and confusing: `loadUrl`
unexpectedly hides the nav overlay. It tries to funnel the code down the
same path but, instead, I think each user action that wants to close the
nav overlay should have an explicit call to hide the overlay. However,
the ScreenController code and session initialization makes this complex
to change currently. As such, the best way to fix the crash was to
remove the assertions.

More generally, I think the assertions are actually not useful:
callers state the desired view state ("when a home tile is pressed, I
want the overlay to be closed") so it adds complexity to sometimes
need to check if the view is in some state before making the call, to
avoid triggering the assertions (e.g. if we're toolbar on startup,
we want to dismiss the nav overlay but don't want to on non-startup).



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
