### PR TITLE
Closes #213: fix Search with Google tile not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Toolbar not updating correctly after application state is restored (#145)
 - A memory leak where the MainActivity was retained after the framework destroyed it (#153)
+- An accessibility problem where an invisible view could steal focus on the home screen (#213)
 
 ## [1.2] - ?
 ### Changed

--- a/app/src/main/java/org/mozilla/focus/browser/HomeTileAdapter.kt
+++ b/app/src/main/java/org/mozilla/focus/browser/HomeTileAdapter.kt
@@ -99,13 +99,9 @@ class HomeTileAdapter(
 
     private fun ViewGroup.setSearchClickListeners(item: HomeTile, urlSearchProvider: () -> UrlSearcher?) {
         // TODO read hint text from Tile, pass through HiddenEditTextManager#attach
-        HiddenEditTextManager.attach(this)
         this.setOnClickListener {
-            HiddenEditTextManager.openSoftKeyboard(it)
+            HiddenEditTextManager.openSoftKeyboard(this, urlSearchProvider)
             TelemetryWrapper.homeTileClickEvent(item)
-        }
-        HiddenEditTextManager.setKeyboardListener(this) { query, autocomplete ->
-            urlSearchProvider()?.onTextInputUrlEntered(query, autocomplete)
         }
     }
 


### PR DESCRIPTION
We currently accept/store keyboard input for the Search with Google tile via a hidden EditText. VoiceView was focusing this EditText, and so an accessibility change was made in f775e90 to make this view unfocusable. This broke the search tile.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] The UI tests are passing for this change
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [X] This PR includes a **CHANGELOG entry** or does not need one
