### PR TITLE
No issue: remove lint from pre-push hook.

### DIFF
--- a/quality/pre-push-recommended.sh
+++ b/quality/pre-push-recommended.sh
@@ -13,7 +13,7 @@
 
 # Descriptions for each gradle task below can be found in the
 # output of `./gradlew tasks`.
-./gradlew --quiet \
+time ./gradlew --quiet \
         checkstyle \
         ktlint \
         pmd \

--- a/quality/pre-push-recommended.sh
+++ b/quality/pre-push-recommended.sh
@@ -20,8 +20,9 @@
         detekt \
         verifyWebViewCount \
         assembleAmazonWebViewDebugAndroidTest \
-        lintAmazonWebViewDebug \
         testAmazonWebViewDebug
 
 # Tasks omitted because they take a long time to run:
 # - unit test on all variants
+# - android lint
+# - androidTest tests (on-device: UI & integration)


### PR DESCRIPTION
We're running lint on travis now so no need to run it locally. According to my
build profile on my 2018 15" MacBook Pro, lint takes ~25s to run out of
a total pre-push build time of 1m20s. This should significantly improve
push times.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] The **UI tests** are passing after this PR (`./gradlew connectedAmazonWebViewDebugAndroidTest`)
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
