### PR TITLE
No issue: disable codecov patch checks.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,11 +7,12 @@ coverage:
   status:
     project:
       default:
+       enabled: no
        threshold: 0.2
        if_not_found: success
     patch:
       default:
-        enabled: yes
+        enabled: no
         if_not_found: success
     changes:
       default:


### PR DESCRIPTION
codecov adds a github comment so we no longer need the patch check to
tell us the percentage change for a patch.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] The **UI tests** are passing after this PR (`./gradlew connectedAmazonWebViewDebugAndroidTest`)
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
