### PR TITLE
Closes #218: Set WebView background color to white.

### DIFF
--- a/app/src/amazonWebview/java/org/mozilla/focus/webview/FirefoxWebView.kt
+++ b/app/src/amazonWebview/java/org/mozilla/focus/webview/FirefoxWebView.kt
@@ -7,6 +7,7 @@ package org.mozilla.focus.webview
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Color
 import android.os.Bundle
 import android.support.annotation.VisibleForTesting
 import android.util.AttributeSet
@@ -48,6 +49,17 @@ internal class FirefoxWebView(
     init {
         setOnLongClickListener(linkHandler)
         isLongClickable = true
+        initBackgroundColor()
+    }
+
+    private fun initBackgroundColor() {
+        // The initial navigation overlay is drawn over the WebView. However, on some Echo Show devices [1], the
+        // overlay fade out animation causes graphical glitches, as if the WebView's background color is transparent
+        // (graphical glitches usually occur when parts of the screen have no draw calls on them). We fix this
+        // issue by defaulting the background to an opaque color.
+        //
+        // [1]: We cannot reproduce on the SF Echo Show but can on the MTV one, despite using similar OS versions.
+        setBackgroundColor(Color.WHITE)
     }
 
     override fun restoreWebViewState(session: Session) {


### PR DESCRIPTION
kglazko confirmed that the speculative fix is working.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - In order to test this, I think we'd need to run an integration test on the device that had the issue and verify that `backgroundColor` is set to white (assuming `backgroundColor` would return something different on that device). This doesn't seem like a useful test because it requires such specific hardware and comes at such a high cost
- [x] This PR includes a **CHANGELOG entry** or does not need one
  - Never introduced to users
- [x] The **UI tests** are passing after this PR (`./gradlew connectedAmazonWebViewDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
