### PR TITLE
No issue: add device resolution to device reference.

### DIFF
--- a/docs/device_reference.md
+++ b/docs/device_reference.md
@@ -4,10 +4,10 @@
 
 There are currently two devices:
 
-| Gen | Release | Code  | OS | Size  | Resources | DPI  | Emulator  |
-|:---:|:-------:|:-----:|:--:|:-----:|:---------:|:----:|:---------:|
-| 2nd | 2018    | AEOBP | 5  | 10.1" | xlarge    | mdpi | WXGA 10.1 |
-| 1st | 2017    | AEOKN | 5  | 7"    | large     | mdpi | ?         |
+| Gen | Release | Code  | OS | Size  | Resources | DPI  | Emulator  | Resolution |
+|:---:|:-------:|:-----:|:--:|:-----:|:---------:|:----:|:---------:|:----------:|
+| 2nd | 2018    | AEOBP | 5  | 10.1" | xlarge    | mdpi | WXGA 10.1 | 1280x800   |
+| 1st | 2017    | AEOKN | 5  | 7"    | large     | mdpi | ?         | 1024x600   |
 
 We recommend **developing** on Android tablet emulators for developer efficiency: the recommended Android emulator images are mentioned above.
 


### PR DESCRIPTION
Measurements were taken from the device. In MainActivity.onCreate:

  val metrics = DisplayMetrics()
  windowManager.defaultDisplay.getMetrics(metrics)
  Log.e("lol", "${metrics.widthPixels}x${metrics.heightPixels}; ${metrics.xdpi}x${metrics.ydpi}")

Note: when calculating the physical measurements from the self-reported
DPI measurements, the results were non-sensical so I didn't include the
DPI or any physical measurements.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] The **UI tests** are passing after this PR (`./gradlew connectedAmazonWebViewDebugAndroidTest`)
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
