### PR TITLE
Issue #186: Refactor IntentValidator to return a value instead of callback

### DIFF
--- a/app/src/main/java/org/mozilla/focus/IntentValidator.kt
+++ b/app/src/main/java/org/mozilla/focus/IntentValidator.kt
@@ -11,7 +11,7 @@ import mozilla.components.support.utils.SafeIntent
 import org.mozilla.focus.session.Source
 import org.mozilla.focus.utils.UrlUtils
 
-typealias OnValidBrowserIntent = (url: String, source: Source) -> Unit
+typealias OnValidBrowserIntent = (url: String) -> Unit
 
 /**
  * A container for functions that parse Intents and notify the application of their validity.
@@ -52,7 +52,7 @@ object IntentValidator {
                 return // If there's no URL in the Intent then we can't create a session.
             }
 
-            onValidBrowserIntent(dataString, Source.VIEW)
+            onValidBrowserIntent(dataString)
         } else if (Intent.ACTION_SEND.equals(action)) {
             val dataString = intent.getStringExtra(Intent.EXTRA_TEXT)
             if (dataString == null || dataString.isEmpty()) {
@@ -61,7 +61,7 @@ object IntentValidator {
 
             val isSearch = !UrlUtils.isUrl(dataString)
             val url = if (isSearch) UrlUtils.createSearchUrl(context, dataString) else dataString
-            onValidBrowserIntent(url, Source.SHARE)
+            onValidBrowserIntent(url)
         }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/IntentValidator.kt
+++ b/app/src/main/java/org/mozilla/focus/IntentValidator.kt
@@ -28,18 +28,28 @@ class IntentValidator(
      * @return the uri for the app to open or null if there is none.
      */
     fun getUriToOpen(context: Context, savedInstanceState: Bundle? = null): String? {
-        if ((intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) {
-            // This Intent was launched from history (recent apps). Android will redeliver the
-            // original Intent (which might be a VIEW intent). However if there's no active browsing
-            // session then we do not want to re-process the Intent and potentially re-open a website
-            // from a session that the user already "erased".
-            return null
+        fun isIntentRedelivered(): Boolean {
+            // This Intent was launched from history (recent apps): this may not be called on Echo Show but
+            // handling it may be useful for testing on the Android emulator.
+            //
+            // I do not know how to reproduce this code path in manual testing.
+            return (intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY != 0) ||
+
+                // The Activity is being restored.
+                //
+                // You can reproduce this code path manually on an Android emulator by enabling don't keep
+                // activities, opening FF, clicking home, opening the recent apps, and opening FF from there.
+                savedInstanceState != null
         }
 
-        if (savedInstanceState != null) {
-            // We are restoring a previous session - No need to handle this Intent.
-            return null
-        }
+        // N.B. the code path for restoring state is hard to understand because this Intent handling code should
+        // be tightly integrated with Android's Activity restoration and our EngineView session restore but it's not.
+        // We could spend time improving this but we should wait to integrate with components first. As such, this
+        // code is similar to how it was when we forked Focus and may do unnecessary things.
+        //
+        // If an intent is being redelivered, we already have some state and our session restore process will handle
+        // restoring it so the redundant Intent is not helpful.
+        if (isIntentRedelivered()) return null
 
         return when (intent.action) {
             // ACTION_VIEW is only sent internally: we want the preinstalled WebView

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -69,7 +69,9 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
 
         setContentView(R.layout.activity_main)
 
-        IntentValidator.validateOnCreate(this, intent, savedInstanceState, ::onValidBrowserIntent)
+        IntentValidator(intent).getUriToOpen(this, savedInstanceState)?.let {
+            onValidBrowserIntent(it)
+        }
         sessionManager.sessions.observe(this, object : NonNullObserver<List<Session>>() {
             public override fun onValueChanged(value: List<Session>) {
                 val sessions = value
@@ -106,7 +108,9 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
     }
 
     override fun onNewIntent(unsafeIntent: Intent) {
-        IntentValidator.validate(this, unsafeIntent.toSafeIntent(), ::onValidBrowserIntent)
+        IntentValidator(unsafeIntent.toSafeIntent()).getUriToOpen(this)?.let {
+            onValidBrowserIntent(it)
+        }
     }
 
     private fun onValidBrowserIntent(url: String) {

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -109,8 +109,9 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
         IntentValidator.validate(this, unsafeIntent.toSafeIntent(), ::onValidBrowserIntent)
     }
 
-    private fun onValidBrowserIntent(url: String, source: Source) {
-        ScreenController.showBrowserScreenForUrl(supportFragmentManager, url, source)
+    private fun onValidBrowserIntent(url: String) {
+        // Source is no longer used by this code base.
+        ScreenController.showBrowserScreenForUrl(supportFragmentManager, url, Source.NONE)
     }
 
     override fun applyLocale() {

--- a/app/src/test/java/org/mozilla/focus/IntentValidatorTest.kt
+++ b/app/src/test/java/org/mozilla/focus/IntentValidatorTest.kt
@@ -27,7 +27,7 @@ class IntentValidatorTest {
     private val context: Context get() = RuntimeEnvironment.application
 
     @Test
-    fun testViewIntent() {
+    fun `WHEN receiving a view intent with a valid uri THEN the uri is returned`() {
         val expectedUrl = TEST_URL
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(expectedUrl)).toSafeIntent()
         val actual = IntentValidator(intent).getUriToOpen(context)
@@ -36,14 +36,16 @@ class IntentValidatorTest {
 
     /** In production we see apps send VIEW intents without an URL. (Focus #1373) */
     @Test
-    fun testViewIntentWithNullURL() {
+    fun `WHEN receiving a view intent with a null uri THEN a null uri is returned`() {
         val intent = Intent(Intent.ACTION_VIEW, null).toSafeIntent()
         val actual = IntentValidator(intent).getUriToOpen(context)
         assertNull(actual)
     }
 
     @Test
-    fun testCustomTabIntent() {
+    fun `WHEN receiving a custom tabs intent with a valid uri THEN the uri is returned`() {
+        // Custom tab intents are view intents. Since FFES doesn't support custom tabs, we don't have code
+        // to handle them specially and we handle them like view intents.
         val expectedUrl = TEST_URL
         val intent = CustomTabsIntent.Builder()
                 .setToolbarColor(Color.GREEN)
@@ -57,7 +59,7 @@ class IntentValidatorTest {
     }
 
     @Test
-    fun testViewIntentFromHistoryIsIgnored() {
+    fun `WHEN receiving a view intent with the launched from history flag THEN a null uri is returned`() {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(TEST_URL)).apply {
             addFlags(Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY)
         }.toSafeIntent()
@@ -66,13 +68,13 @@ class IntentValidatorTest {
     }
 
     @Test
-    fun testIntentNotValidIfWeAreRestoring() {
+    fun `WHEN restoring state THEN a null uri is returned`() {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(TEST_URL)).toSafeIntent()
         assertNull(IntentValidator(intent).getUriToOpen(context, Bundle()))
     }
 
     @Test
-    fun testShareIntentViaNewIntent() {
+    fun `WHEN receiving a send intent with a valid uri THEN the uri is returned`() {
         val expectedUrl = TEST_URL
         val intent = Intent(Intent.ACTION_SEND).apply {
             putExtra(Intent.EXTRA_TEXT, expectedUrl)
@@ -82,7 +84,7 @@ class IntentValidatorTest {
     }
 
     @Test
-    fun testShareIntentWithTextViaNewIntent() {
+    fun `WHEN receiving a send intent with text THEN a search uri is returned`() {
         val expectedText = "Hello World Firefox TV"
         val intent = Intent(Intent.ACTION_SEND).apply {
             putExtra(Intent.EXTRA_TEXT, expectedText)

--- a/app/src/test/java/org/mozilla/focus/IntentValidatorTest.kt
+++ b/app/src/test/java/org/mozilla/focus/IntentValidatorTest.kt
@@ -15,7 +15,6 @@ import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.focus.ext.toSafeIntent
-import org.mozilla.focus.session.Source
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
@@ -29,10 +28,9 @@ class IntentValidatorTest {
         var isCalled = false
         val expectedUrl = TEST_URL
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(expectedUrl)).toSafeIntent()
-        IntentValidator.validate(RuntimeEnvironment.application, intent) { url, source ->
+        IntentValidator.validate(RuntimeEnvironment.application, intent) { url ->
             isCalled = true
             assertEquals(expectedUrl, url)
-            assertEquals(Source.VIEW, source)
         }
 
         assertTrue("Expected intent to be valid", isCalled)
@@ -42,7 +40,7 @@ class IntentValidatorTest {
     @Test
     fun testViewIntentWithNullURL() {
         val intent = Intent(Intent.ACTION_VIEW, null).toSafeIntent()
-        IntentValidator.validate(RuntimeEnvironment.application, intent) { _, _ ->
+        IntentValidator.validate(RuntimeEnvironment.application, intent) { _ ->
             fail("Null URL should not be valid")
         }
     }
@@ -59,10 +57,9 @@ class IntentValidatorTest {
                 .toSafeIntent()
 
         var isCalled = false
-        IntentValidator.validate(RuntimeEnvironment.application, intent) { url, source ->
+        IntentValidator.validate(RuntimeEnvironment.application, intent) { url ->
             isCalled = true
             assertEquals(expectedUrl, url)
-            assertEquals(Source.VIEW, source)
         }
 
         assertTrue("Expected intent to be valid", isCalled)
@@ -95,9 +92,8 @@ class IntentValidatorTest {
         }.toSafeIntent()
 
         var isCalled = false
-        IntentValidator.validate(RuntimeEnvironment.application, intent) { url, source ->
+        IntentValidator.validate(RuntimeEnvironment.application, intent) { url ->
             isCalled = true
-            assertEquals(Source.SHARE, source)
             assertEquals(expectedUrl, url)
         }
 
@@ -112,9 +108,8 @@ class IntentValidatorTest {
         }.toSafeIntent()
 
         var isCalled = false
-        IntentValidator.validate(RuntimeEnvironment.application, intent) { url, source ->
+        IntentValidator.validate(RuntimeEnvironment.application, intent) { url ->
             isCalled = true
-            assertEquals(Source.SHARE, source)
             expectedText.split(" ").forEach {
                 assertTrue("Expected search url to contain $it", url.contains(it))
             }


### PR DESCRIPTION
There is no user facing behavior change. In the code, we no longer use the Session.source property, but that isn't really used anyway. Returning a value, rather than calling a callback, should make this code more flexible for other use cases.

I thought about refactoring this more heavily to clarify the entire session restoration flow but it's a big undertaking because we'd have to clarify how sessions are created/managed, which we should really wait for components to do (because the session APIs might change slightly). As such, I opted for clarifying comments instead.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
  - not user facing
- [x] The **UI tests** are passing after this PR (`./gradlew connectedAmazonWebViewDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
