### PR TITLE
Closes #39: Wrap UserClearDataEvent in consumable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Under unlikely state restoration circumstances, a user who cleared their data could unexpectedly experience the data clear multiple times (#39)
 
 ## [1.3] - ?
 ### Added

--- a/app/src/main/java/org/mozilla/focus/settings/ClearDataFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/ClearDataFragment.kt
@@ -12,6 +12,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import kotlinx.android.synthetic.main.fragment_cleardata.*
+import mozilla.components.support.base.observer.Consumable
 import org.mozilla.focus.R
 import org.mozilla.focus.iwebview.WebViewProvider
 import org.mozilla.focus.telemetry.TelemetryWrapper
@@ -24,11 +25,11 @@ import org.mozilla.focus.utils.LiveDataEvent
  * This class wraps the file-private mutable LiveData instance in a read-only interface exposed
  * outside of this file.
  */
-object UserClearDataEvent { val liveData: LiveData<LiveDataEvent> = mutableClearEventLiveData }
-private val mutableClearEventLiveData = MutableLiveData<LiveDataEvent>()
+object UserClearDataEvent { val liveData: LiveData<Consumable<LiveDataEvent>> = mutableClearEventLiveData }
+private val mutableClearEventLiveData = MutableLiveData<Consumable<LiveDataEvent>>()
 
 // Wrap the LiveData assignment in a function to explain what it does.
-private fun sendUserClearDataEvent() { mutableClearEventLiveData.value = LiveDataEvent() }
+private fun sendUserClearDataEvent() { mutableClearEventLiveData.value = Consumable.from(LiveDataEvent) }
 
 /**
  * Fragment used in Settings to clear cookies and browsing history.

--- a/app/src/main/java/org/mozilla/focus/settings/UserClearDataEventObserver.kt
+++ b/app/src/main/java/org/mozilla/focus/settings/UserClearDataEventObserver.kt
@@ -6,18 +6,24 @@ package org.mozilla.focus.settings
 
 import android.arch.lifecycle.Observer
 import android.support.v7.app.AppCompatActivity
+import mozilla.components.support.base.observer.Consumable
 import org.mozilla.focus.ScreenController
 import org.mozilla.focus.utils.LiveDataEvent
 
 /** An observer for when the user clears their browsing data. See [UserClearDataEvent] for details. */
-class UserClearDataEventObserver(private val activity: AppCompatActivity) : Observer<LiveDataEvent> {
-    override fun onChanged(event: LiveDataEvent?) {
-        // The global WebView state has been destroyed by Settings but we must still clean up
-        // local WebView state. The browserFragment's initial state is that there is 1) no page
-        // loaded and 2) there is no back stack. However, this is impossible to replicate in an
-        // existing BrowserFragment: loading a blank page will add a page to the back stack. As
-        // such, our only option is to remove and recreate the BrowserFragment. This is more correct
-        // because it creates a new session too.
-        ScreenController.recreateBrowserScreen(activity.supportFragmentManager)
+class UserClearDataEventObserver(
+    private val activity: AppCompatActivity
+) : Observer<Consumable<LiveDataEvent>> {
+    override fun onChanged(event: Consumable<LiveDataEvent>?) {
+        event?.consume {
+            // The global WebView state has been destroyed by Settings but we must still clean up
+            // local WebView state. The browserFragment's initial state is that there is 1) no page
+            // loaded and 2) there is no back stack. However, this is impossible to replicate in an
+            // existing BrowserFragment: loading a blank page will add a page to the back stack. As
+            // such, our only option is to remove and recreate the BrowserFragment. This is more correct
+            // because it creates a new session too.
+            ScreenController.recreateBrowserScreen(activity.supportFragmentManager)
+            true
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/focus/utils/LiveDataEvent.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/LiveDataEvent.kt
@@ -11,4 +11,4 @@ package org.mozilla.focus.utils
  * This implementation is inspired by:
  *   https://medium.com/google-developers/livedata-with-snackbar-navigation-and-other-events-the-singleliveevent-case-ac2622673150
  */
-class LiveDataEvent
+object LiveDataEvent


### PR DESCRIPTION
This is an accepted pattern on our team to send single-use events
through an Observable.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - I've spent too long on #186 and this requires some rethinking about how to test it that I don't want to put in. It's an accepted pattern on our team so I think it's a safe change.
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] The **UI tests** are passing after this PR (`./gradlew connectedAmazonWebViewDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
