### PR TITLE
No Issue: Use "labels" for issue template labeling front matter

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F41E Bug report"
 about: Create a report to help us improve
-label: "bug"
+labels: "bug"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/---chore.md
+++ b/.github/ISSUE_TEMPLATE/---chore.md
@@ -1,6 +1,6 @@
 ---
 name: "🧶 Chore"
 about: Tech debt, developer ergonomics, tooling, etc.
-label: "chore"
+labels: "chore"
 
 ---

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -1,7 +1,7 @@
 ---
 name: "⭐️ Feature request"
 about: Suggest an idea for this project
-label: "feature"
+labels: "feature"
 
 ---
 


### PR DESCRIPTION
Small typo changing "label" to "labels" per:
https://help.github.com/en/articles/manually-creating-a-single-issue-template-for-your-repository