### PR TITLE
Closes #267: use viewLifecycleOwner instead of adding/removing observers

### DIFF
--- a/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
+++ b/app/src/main/java/org/mozilla/focus/home/NavigationOverlayFragment.kt
@@ -48,7 +48,6 @@ class NavigationOverlayFragment : Fragment() {
 
     private val callbacks: BrowserFragmentCallbacks? get() = activity as BrowserFragmentCallbacks?
     private val viewUiCoroutineScope = FragmentViewUiCoroutineScope()
-    private val googleSearchFocusRequestObserver = GoogleSearchFocusRequestObserver()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         viewUiCoroutineScope.onCreateView()
@@ -66,8 +65,7 @@ class NavigationOverlayFragment : Fragment() {
 
         // We forward the google search event to the default search engine: Google.
         overlay.googleSearchHiddenEditText.setOnEditorActionListener(DefaultSearchOnEditorActionListener(activity as UrlSearcher))
-        // TODO: use lifecycle view owner with SDK 28.
-        context.serviceLocator.pinnedTileRepo.googleSearchEvents.observe(this, googleSearchFocusRequestObserver)
+        context.serviceLocator.pinnedTileRepo.googleSearchEvents.observe(viewLifecycleOwner, GoogleSearchFocusRequestObserver())
 
         NavigationOverlayAnimations.onCreateViewAnimateIn(overlay, isOverlayOnStartup, isBeingRestored = savedInstanceState != null) {
             // We defer setting click listeners until the animation completes
@@ -80,7 +78,6 @@ class NavigationOverlayFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        context!!.serviceLocator.pinnedTileRepo.googleSearchEvents.removeObserver(googleSearchFocusRequestObserver)
         viewUiCoroutineScope.onDestroyView()
     }
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - Code swap, no need to add tests
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] The **UI tests** are passing after this PR (`./gradlew connectedAmazonWebViewDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
