### PR TITLE
Closes #297: Set default overlay visible value to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Under unlikely state restoration circumstances, a user who cleared their data could unexpectedly experience the data clear multiple times (#39)
+- If the session is restored, the toolbar does not go away (#297)
 
 ## [1.3.1] - 2019-07-??
 *This version is identical to v1.3 except for minor build differences. Issue #280 is not reproducible in new local builds, so we are resubmitting the same code to see if this corrects the issue in production.*

--- a/app/src/main/java/org/mozilla/focus/toolbar/BrowserAppBarViewModel.kt
+++ b/app/src/main/java/org/mozilla/focus/toolbar/BrowserAppBarViewModel.kt
@@ -21,6 +21,8 @@ class BrowserAppBarViewModel(
 ) : ViewModel() {
 
     private val isNavigationOverlayVisible = MutableLiveData<Boolean>().apply {
+        // This value changes when the overlay changes visibility. It has a default value of false since
+        // the overlay is hidden by default; this is particularly important for the case of session restoration.
         value = false
     }
 

--- a/app/src/main/java/org/mozilla/focus/toolbar/BrowserAppBarViewModel.kt
+++ b/app/src/main/java/org/mozilla/focus/toolbar/BrowserAppBarViewModel.kt
@@ -20,7 +20,9 @@ class BrowserAppBarViewModel(
     sessionRepo: SessionRepo
 ) : ViewModel() {
 
-    private val isNavigationOverlayVisible = MutableLiveData<Boolean>()
+    private val isNavigationOverlayVisible = MutableLiveData<Boolean>().apply {
+        value = false
+    }
 
     val isToolbarScrollEnabled = LiveDataCombiners.combineLatest(
         frameworkRepo.isVoiceViewEnabled,

--- a/app/src/test/java/org/mozilla/focus/toolbar/BrowserAppBarViewModelTest.kt
+++ b/app/src/test/java/org/mozilla/focus/toolbar/BrowserAppBarViewModelTest.kt
@@ -47,7 +47,7 @@ class BrowserAppBarViewModelTest {
 
     @Test
     fun `GIVEN voiceView is disabled WHEN navigation overlay is visible THEN toolbar scroll is disabled`() {
-        viewModel.isToolbarScrollEnabled.assertValues(false) {
+        viewModel.isToolbarScrollEnabled.assertValues(true, false) {
             isVoiceViewEnabled.value = false
             viewModel.onNavigationOverlayVisibilityChange(true)
         }
@@ -55,7 +55,7 @@ class BrowserAppBarViewModelTest {
 
     @Test
     fun `GIVEN voiceView is disabled WHEN navigation overlay is not visible THEN toolbar scroll is enabled`() {
-        viewModel.isToolbarScrollEnabled.assertValues(true) {
+        viewModel.isToolbarScrollEnabled.assertValues(true, true) {
             isVoiceViewEnabled.value = false
             viewModel.onNavigationOverlayVisibilityChange(false)
         }
@@ -63,7 +63,7 @@ class BrowserAppBarViewModelTest {
 
     @Test
     fun `GIVEN voiceView is enabled THEN toolbar scroll is always disabled`() {
-        viewModel.isToolbarScrollEnabled.assertValues(false, false) {
+        viewModel.isToolbarScrollEnabled.assertValues(false, false, false) {
             isVoiceViewEnabled.value = true
             viewModel.onNavigationOverlayVisibilityChange(false)
             viewModel.onNavigationOverlayVisibilityChange(true)


### PR DESCRIPTION
On session restore, the `isToolbarScrollEnabled` value was not set correctly to true because the overlay was not visited first, and that is when the value changes. Setting `isNavigationOverlayVisible` default to false is the fix.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] The **UI tests** are passing after this PR (`./gradlew connectedAmazonWebViewDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
