### PR TITLE
Issue #305: video pauses when app bar scrolls off screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Under unlikely state restoration circumstances, a user who cleared their data could unexpectedly experience the data clear multiple times (#39)
 - If the session is restored, the toolbar does not go away (#297)
+- WebView video would pause on ES5 when the App Bar scrolls off screen (#305)
 
 ## [1.3.1] - 2019-07-??
 *This version is identical to v1.3 except for minor build differences. Issue #280 is not reproducible in new local builds, so we are resubmitting the same code to see if this corrects the issue in production.*

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -114,8 +114,8 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
             }
         }
 
-        toolbarCallbacks = ToolbarIntegration.setup(this, activityUiScope, toolbarViewModel, toolbar, toolbarStateProvider,
-            ::onToolbarEvent)
+        toolbarCallbacks = ToolbarIntegration.setup(this, activityUiScope, toolbarViewModel,
+            appBarInnerContainer, toolbar, toolbarStateProvider, ::onToolbarEvent)
     }
 
     override fun onNewIntent(unsafeIntent: Intent) {

--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -109,7 +109,7 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
 
     private fun initViews() {
         FirefoxViewModelProviders.of(this)[BrowserAppBarViewModel::class.java].let { viewModel ->
-            appBarLayoutController = BrowserAppBarLayoutController(viewModel, appBarLayout, toolbar).apply {
+            appBarLayoutController = BrowserAppBarLayoutController(viewModel, appBarLayout).apply {
                 init(this@MainActivity)
             }
         }
@@ -222,3 +222,23 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
                 .start()
     }
 }
+
+/**
+ * Fetches the semiOpaqueBackground that overlays the AppBar. See the definition of
+ * R.id.appBarLayout in XML for why this view exists at all.
+ *
+ * We create this fragile view accessor, that encourages the breaking of encapsulation, because
+ * refactoring the code to avoid it isn't a good use of time at present. Specifically, there are two
+ * views, one in [MainActivity] and one in [NavigationOverlayFragment], that need to call into the
+ * other component in order to indicate success and cross-component communication is hard (and
+ * direct communication is deprecated) in this codebase. We could try to abstract them into Repos
+ * and ViewModels but those also don't exist.
+ *
+ * TODO: remove this HACK: see above for why this is bad.
+ *
+ * This property lives in MainActivity, rather than the places it's accessed from, because it
+ * references a View that lives in MainActivity. It's an extension function on View to guarantee we
+ * have a Context and view hierarchy available.
+ */
+@Deprecated("Prefer refactoring your code so this is unnecessary rather than using this directly")
+val View.appBarSemiOpaqueBackground: View get() = (this.context as MainActivity).appBarSemiOpaqueBackground

--- a/app/src/main/java/org/mozilla/focus/toolbar/BrowserAppBarLayoutController.kt
+++ b/app/src/main/java/org/mozilla/focus/toolbar/BrowserAppBarLayoutController.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.focus.toolbar
 
+import android.view.ViewGroup
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.Observer
@@ -12,6 +13,7 @@ import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_
 import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_EXIT_UNTIL_COLLAPSED
 import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_SCROLL
 import com.google.android.material.appbar.AppBarLayout.LayoutParams.SCROLL_FLAG_SNAP
+import kotlinx.android.synthetic.main.activity_main.view.*
 import mozilla.components.browser.toolbar.BrowserToolbar
 import org.mozilla.focus.ext.updateLayoutParams
 
@@ -23,14 +25,13 @@ private const val TOOLBAR_SCROLL_ENABLED_FLAGS = SCROLL_FLAG_SCROLL or
 /** A view controller for the [AppBarLayout] and the [BrowserToolbar] it contains. */
 class BrowserAppBarLayoutController(
     private val viewModel: BrowserAppBarViewModel,
-    private val appBarLayout: AppBarLayout,
-    private val toolbar: BrowserToolbar
+    private val appBarLayout: AppBarLayout
 ) : LifecycleObserver {
 
     fun init(lifecycleOwner: LifecycleOwner) {
         lifecycleOwner.lifecycle.addObserver(this)
         viewModel.isToolbarScrollEnabled.observe(lifecycleOwner, Observer {
-            toolbar.setIsScrollEnabled(it!!)
+            appBarLayout.appBarInnerContainer.setIsScrollEnabled(it!!)
         })
 
         viewModel.isAppBarHidden.observe(lifecycleOwner, Observer {
@@ -47,7 +48,7 @@ class BrowserAppBarLayoutController(
     }
 }
 
-private fun BrowserToolbar.setIsScrollEnabled(isScrollEnabled: Boolean) {
+private fun ViewGroup.setIsScrollEnabled(isScrollEnabled: Boolean) {
     updateLayoutParams {
         val layoutParams = it as AppBarLayout.LayoutParams
 

--- a/app/src/main/java/org/mozilla/focus/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/focus/toolbar/ToolbarIntegration.kt
@@ -158,7 +158,11 @@ object ToolbarIntegration {
         onToolbarEvent: OnToolbarEvent
     ): ChangeableVisibilityButton {
         val res = context.resources
+
         fun getDrawable(@DrawableRes drawableId: Int): Drawable =
+            // The linter warns "Expected resource of type drawable" but we are passing
+            // in a Drawable resource: this is a suspected bug so we suppress it.
+            @Suppress("ResourceType")
             AppCompatResources.getDrawable(context, drawableId)!!
 
         val homescreenButton = BrowserToolbar.Button(

--- a/app/src/main/java/org/mozilla/focus/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/focus/toolbar/ToolbarIntegration.kt
@@ -19,6 +19,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import kotlinx.android.synthetic.main.activity_main.view.*
 import kotlinx.coroutines.CoroutineScope
 import mozilla.components.browser.domains.DomainAutoCompleteProvider
 import mozilla.components.browser.toolbar.BrowserToolbar
@@ -89,6 +90,7 @@ object ToolbarIntegration {
         lifecycleOwner: LifecycleOwner,
         uiScope: CoroutineScope,
         viewModel: ToolbarViewModel,
+        toolbarContainer: ViewGroup,
         toolbar: BrowserToolbar,
         toolbarStateProvider: ToolbarStateProvider,
         onToolbarEvent: OnToolbarEvent
@@ -96,7 +98,7 @@ object ToolbarIntegration {
         val context = toolbar.context
 
         viewModel.isToolbarImportantForAccessibility.observe(lifecycleOwner, Observer {
-            toolbar.setIsImportantForAccessibility(it!!)
+            toolbarContainer.setIsImportantForAccessibility(it!!)
         })
 
         toolbar.displaySiteSecurityIcon = false
@@ -368,7 +370,7 @@ private val BrowserToolbar.editToolbar: ViewGroup
     // The class is internal so we compare against its name instead of its type.
     get() = children().first { it::class.java.simpleName == "EditToolbar" } as ViewGroup
 
-private fun BrowserToolbar.setIsImportantForAccessibility(isImportantForAccessibility: Boolean) {
+private fun View.setIsImportantForAccessibility(isImportantForAccessibility: Boolean) {
     // The open-navigation-overlay button will remain focused unless another view requests focus
     // (which we expect to happen). We could clear focus here to decouple this code but it's
     // unfortunately non-trivial.

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -42,7 +42,9 @@
              we need this inner ViewGroup.
 
              CoordinatorLayout scroll flags are added dynamically: see
-             BrowserAppBarLayoutController's ViewGroup.setIsScrollEnabled. -->
+             BrowserAppBarLayoutController's ViewGroup.setIsScrollEnabled.
+
+             The accessibility of this view is changed dynamically: see ToolbarIntegration. -->
         <FrameLayout
                 android:id="@+id/appBarInnerContainer"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -17,21 +17,51 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         />
 
-    <!-- Ideally, we have no elevation on the initial homescreen and elevation over web content. However, the elevation
-         over web content is broken so we set it to 0 for all cases. -->
+    <!-- The designs state we should have no elevation shadow on the initial homescreen and an
+	     elevation shadow over web content. However, the elevation shadow over web content
+	     is broken so we could just set elevation to 0 everywhere.  However, on Echo Show
+	     5, for an unknown reason setting any elevation on this view will cause the
+	     WebView to stop playing videos when the AppBar scrolls offscreen (#305). As such,
+	     we do not modify the elevation.  One side effect of this is that an elevation
+	     shadow undesirably appears on the initial homescreen. In theory, we can selectively
+	     enable this fix on ES 5 to prevent this issue from appearing on all devices but I
+	     (mcomella) don't think it's worth the complexity.
+
+         Unfortunately, not modifying the elevation also means the NavigationOverlay's
+         semi opaque background will not appear over the AppBar, even if the semi opaque
+         background's elevation is set very high. As such, we add a separate semi opaque
+         view inside this AppBar layout that appears together with the NavigationOverlay's
+         so that the entire screen is covered. -->
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appBarLayout"
         android:layout_width="match_parent"
         android:layout_height="@dimen/appbar_height"
-        android:background="@color/photonGrey70"
-        app:elevation="0dp">
+        android:background="@color/photonGrey70">
 
-        <!-- CoordinatorLayout scroll flags are added dynamically: see
-             BrowserAppBarLayoutController.updateCanScroll. -->
-        <mozilla.components.browser.toolbar.BrowserToolbar
-            android:id="@+id/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"/>
+        <!-- AppBarLayout is a LinearLayout so to have two views overlap & fill the space,
+             we need this inner ViewGroup.
+
+             CoordinatorLayout scroll flags are added dynamically: see
+             BrowserAppBarLayoutController's ViewGroup.setIsScrollEnabled. -->
+        <FrameLayout
+                android:id="@+id/appBarInnerContainer"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+            <mozilla.components.browser.toolbar.BrowserToolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
+
+            <!-- See containing AppBarLayout for details. Visibility updated dynamically. -->
+            <View
+                android:id="@+id/appBarSemiOpaqueBackground"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@color/nav_overlay_semi_opaque_background"
+                android:visibility="gone"/>
+
+        </FrameLayout>
     </com.google.android.material.appbar.AppBarLayout>
 
     <FrameLayout

--- a/app/src/main/res/layout/fragment_navigation_overlay.xml
+++ b/app/src/main/res/layout/fragment_navigation_overlay.xml
@@ -41,7 +41,7 @@
             android:id="@+id/semiOpaqueBackground"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="@color/photonGrey90_a60p"
+            android:background="@color/nav_overlay_semi_opaque_background"
             android:focusable="false"/>
 
     <!-- Available in dialog mode, this is the hit target - i.e. not visible - to dismiss the overlay because the

--- a/app/src/main/res/layout/fragment_navigation_overlay.xml
+++ b/app/src/main/res/layout/fragment_navigation_overlay.xml
@@ -35,12 +35,20 @@
             android:imeActionId="@integer/ime_action_search"
             android:importantForAccessibility="no"/>
 
-    <!-- Visible in dialog mode, this is the semi opaque background that obscures the URL bar. If focusable,
-         this view is accessible by the screen reader through the overlay background where there aren't home tiles. -->
+    <!-- Visible in dialog mode, this is the semi opaque background sits behind the nav overlay. We
+         set not focusable because if it's focusable, this view is accessible by the screen reader
+         through the overlay background where there aren't home tiles.
+
+         This doesn't cover the AppBar (due to marginTop): another view does. That's necessary
+         because this view does not cover the App Bar unless we're animating so we have to make sure
+         these views do not overlap. See appBarSemiOpaqueBackground for a longer explanation. -->
     <View
             android:id="@+id/semiOpaqueBackground"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:layout_marginTop="@dimen/appbar_height"
             android:background="@color/nav_overlay_semi_opaque_background"
             android:focusable="false"/>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -20,4 +20,6 @@
     <color name="amazon_settings_textcolor">@color/photonGrey10</color>
     <color name="amazon_toggle_on">#00CAFF</color>
     <color name="amazon_toggle_off">#F0F1EF</color>
+
+    <color name="nav_overlay_semi_opaque_background">@color/photonGrey90_a60p</color>
 </resources>

--- a/app/src/test/java/org/mozilla/focus/toolbar/BrowserAppBarLayoutControllerTest.kt
+++ b/app/src/test/java/org/mozilla/focus/toolbar/BrowserAppBarLayoutControllerTest.kt
@@ -4,12 +4,11 @@
 
 package org.mozilla.focus.toolbar
 
+import androidx.appcompat.app.AppCompatActivity
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MutableLiveData
 import com.google.android.material.appbar.AppBarLayout
-import androidx.appcompat.app.AppCompatActivity
-import mozilla.components.browser.toolbar.BrowserToolbar
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -52,8 +51,7 @@ class BrowserAppBarLayoutControllerTest {
         }
 
         appBarLayout = mock(AppBarLayout::class.java)
-        val toolbar = mock(BrowserToolbar::class.java)
-        initController = BrowserAppBarLayoutController(viewModel, appBarLayout, toolbar).apply {
+        initController = BrowserAppBarLayoutController(viewModel, appBarLayout).apply {
             init(lifecycleOwner)
         }
     }


### PR DESCRIPTION
RCA: setting an elevation on the AppBar will pause playing WebView
videos when the AppBar is scrolled off-screen for an unknown reason. See
XML for details.

@brampitoyo @athomasmoz FYI: one side-effect of this change is that the AppBar displays a shadow on
the initial homescreen (i.e. only on cold start) on all devices: I didn't feel it was worth the
complexity to selectively enable this fix on different devices to avoid
this on all devices but the ES5. Here's a screenshot:

![device-2019-09-30-141245](https://user-images.githubusercontent.com/759372/65919715-04fe0f00-e392-11e9-8c42-4cbe9ccfe7f5.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - All UX change
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] The **UI tests** are passing after this PR (`./gradlew connectedAmazonWebViewDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
