### PR TITLE
Closes #314: selectively enable toolbar elevation on some devices

### DIFF
--- a/app/src/main/java/org/mozilla/focus/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/focus/MainActivity.kt
@@ -19,6 +19,7 @@ import org.mozilla.focus.browser.BrowserFragmentCallbacks
 import org.mozilla.focus.ext.getBrowserFragment
 import org.mozilla.focus.ext.getNavigationOverlay
 import org.mozilla.focus.ext.isVisibleAndNonNull
+import org.mozilla.focus.ext.serviceLocator
 import org.mozilla.focus.ext.toSafeIntent
 import org.mozilla.focus.iwebview.IWebView
 import org.mozilla.focus.iwebview.WebViewProvider
@@ -109,7 +110,7 @@ class MainActivity : LocaleAwareAppCompatActivity(), BrowserFragmentCallbacks, U
 
     private fun initViews() {
         FirefoxViewModelProviders.of(this)[BrowserAppBarViewModel::class.java].let { viewModel ->
-            appBarLayoutController = BrowserAppBarLayoutController(viewModel, appBarLayout).apply {
+            appBarLayoutController = BrowserAppBarLayoutController(viewModel, appBarLayout, serviceLocator.deviceInfo).apply {
                 init(this@MainActivity)
             }
         }

--- a/app/src/main/java/org/mozilla/focus/utils/DeviceInfo.kt
+++ b/app/src/main/java/org/mozilla/focus/utils/DeviceInfo.kt
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.focus.utils
+
+import android.os.Build
+
+/**
+ * Helpers that help identify a device.
+ */
+class DeviceInfo {
+
+    /** Echo Show models. */
+    enum class Model {
+        FIVE,
+        SECOND_GEN,
+        FIRST_GEN,
+
+        UNKNOWN
+    }
+
+    /**
+     * The model name of the current device. In general, you should use the resource system over
+     * this to more robustly identify device configurations rather than specific devices: see
+     * https://github.com/mozilla-mobile/firefox-echo-show/blob/master/docs/device_reference.md#distinguishing-devices-in-code
+     * for details.
+     */
+    val deviceModel: Model by lazy {
+        when (Build.MODEL) {
+            "AEOCH" -> Model.FIVE
+            "AEOBP" -> Model.SECOND_GEN
+            "AEOKN" -> Model.FIRST_GEN
+
+            else -> Model.UNKNOWN
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/focus/widget/ServiceLocator.kt
+++ b/app/src/main/java/org/mozilla/focus/widget/ServiceLocator.kt
@@ -9,6 +9,7 @@ import org.mozilla.focus.architecture.FrameworkRepo
 import org.mozilla.focus.ext.getAccessibilityManager
 import org.mozilla.focus.home.PinnedTileRepo
 import org.mozilla.focus.session.SessionRepo
+import org.mozilla.focus.utils.DeviceInfo
 
 /**
  * Implementation of the Service Locator pattern. Use this class to provide dependencies without
@@ -46,6 +47,8 @@ open class ServiceLocator private constructor() {
     val frameworkRepo = FrameworkRepo()
     val sessionRepo = SessionRepo()
     val pinnedTileRepo = PinnedTileRepo()
+
+    val deviceInfo by lazy { DeviceInfo() }
 
     private fun init(applicationContext: Context) {
         // The touch state listener gets called even when the application is backgrounded so we only need to add it once.

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -23,9 +23,8 @@
 	     5, for an unknown reason setting any elevation on this view will cause the
 	     WebView to stop playing videos when the AppBar scrolls offscreen (#305). As such,
 	     we do not modify the elevation.  One side effect of this is that an elevation
-	     shadow undesirably appears on the initial homescreen. In theory, we can selectively
-	     enable this fix on ES 5 to prevent this issue from appearing on all devices but I
-	     (mcomella) don't think it's worth the complexity.
+	     shadow undesirably appears on the initial homescreen. Therefore, in code we selectively
+	     set the AppBar elevation to zero on devices that are not affected by this issue.
 
          Unfortunately, not modifying the elevation also means the NavigationOverlay's
          semi opaque background will not appear over the AppBar, even if the semi opaque

--- a/app/src/test/java/org/mozilla/focus/toolbar/BrowserAppBarLayoutControllerTest.kt
+++ b/app/src/test/java/org/mozilla/focus/toolbar/BrowserAppBarLayoutControllerTest.kt
@@ -19,6 +19,8 @@ import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import org.mozilla.focus.utils.DeviceInfo
+import org.mozilla.focus.utils.DeviceInfo.Model
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 
@@ -51,7 +53,11 @@ class BrowserAppBarLayoutControllerTest {
         }
 
         appBarLayout = mock(AppBarLayout::class.java)
-        initController = BrowserAppBarLayoutController(viewModel, appBarLayout).apply {
+        val deviceInfo = mock(DeviceInfo::class.java).apply {
+            `when`(this.deviceModel).thenReturn(Model.UNKNOWN)
+        }
+
+        initController = BrowserAppBarLayoutController(viewModel, appBarLayout, deviceInfo).apply {
             init(lifecycleOwner)
         }
     }


### PR DESCRIPTION
@brampitoyo FYI: the shadow on the initial homescreen (there's a screenshot in the issue) appears only on the ES 5 now, which is the only device affected by this bug.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] This PR includes thorough **tests** or an explanation of why it does not
  - Not worth the time
- [x] This PR includes a **CHANGELOG entry** or does not need one
- [x] The **UI tests** are passing after this PR (`./gradlew connectedAmazonWebViewDebugAndroidTest`)
- [x] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
