### PR TITLE
Closes #326: call zipalign before sending to autograph server

### DIFF
--- a/tools/sign_release.sh
+++ b/tools/sign_release.sh
@@ -23,7 +23,7 @@
 # Crash script if any command exits with non-zero status
 set -e
 
-BUILD_TOOLS=~/Library/Android/sdk/build-tools/28.0.2 # Update me on error!
+BUILD_TOOLS=~/Library/Android/sdk/build-tools/29.0.3 # Update me on error!
 
 BUILD_DIR=app/build/outputs/apk/amazonWebview/release
 FINAL_NAME=app-amazonWebview-release.apk


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] This PR includes thorough **tests** or an explanation of why it does not
- [ ] This PR includes a **CHANGELOG entry** or does not need one
- [ ] The **UI tests** are passing after this PR (`./gradlew connectedAmazonWebViewDebugAndroidTest`)
- [ ] I have considered adding **QA labels** on the associated issue (not this PR; `qa-ready` or `qa-denied`)
